### PR TITLE
Jms integrate test repo

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -17,18 +17,6 @@ jobs:
       with:
         tags: true
 
-    - name: Check for Tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-        if [ $(git tag | wc -l) -eq 0 ]; then
-          echo "No tags found, setting initial tag to v1.0.0"
-          git tag v1.0.0
-          git push --tags
-          echo "tag_setup=true" >> ${GITHUB_OUTPUT}
-        fi
-
     - name: Generate Changelog
       id: changelog
       uses: mikepenz/release-changelog-builder-action@v4.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# Standard .NET and Visual Studio files/directories
+[Bb]in/
+[Oo]bj/
+[Ll]ogs/
+[Pp]ackages/
+[Tt]est[Rr]esults/
+.vs/
+
+# OS specific files
+# macOS
+.DS_Store
+# Windows
+Thumbs.db
+Desktop.ini
+# Linux
+.directory
+.*.sw?
+.bash_history
+# Temporary files
+*~
+
+# Generated files
+*.user
+*.userosscache
+*.suo
+*.userprefs
+*.pidb
+*.cache
+*.vsp
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.sln.docstates
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# BenchmarkDotNet Artifacts
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# Files built by Visual Studio
+*_i.h
+*_p.h
+*_i.cpp
+*_p.cpp
+*_h.h
+*_h.cpp
+*_i.cs
+*_p.cs
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# NuGet Packages Directory
+*.nupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+*.[Cc]ache
+!*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+*.snk
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file to a newer
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This GitHub Action is designed to provide a simple and effective way to build an
 | `dotnet-version`           | The .NET SDK version to use.                         | No       | `6.0`    |
 | `build-configuration`      | Configuration to use for building the project.       | No       | `Release`|
 | `test-verbosity`           | Set the verbosity of test results.                   | No       | `normal` |
+| `solution-path`            | Path to the solution file.                           | No       | `'.'`    |
 | `additional-build-arguments`| Any additional arguments to include with your build command | No | `''` |
 | `additional-test-arguments`| Any additional arguments to include with your test command | No | `''` |
 
@@ -57,6 +58,8 @@ jobs:
           dotnet-version: '7.0'
           build-configuration: 'Debug'
           test-verbosity: 'detailed'
+          additional-build-arguments: '--warnaserror'
+          additional-test-arguments: '--filter "Category!=Integration"'
 ```
 
 If there are additionall CI steps you wish to run such as SonarQube coverage, simply add them as additional steps.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This GitHub Action is designed to provide a simple and effective way to build an
 
 | Input                      | Description                                          | Required | Default  |
 |----------------------------|------------------------------------------------------|----------|----------|
-| `dotnet-version`           | The .NET SDK version to use.                         | No       | `6.0`    |
+| `nuget-api-key` | The NuGet key set in your repo | Yes | '' |
+|`dotnet-version`           | The .NET SDK version to use.                         | No       | `6.0`    |
 | `build-configuration`      | Configuration to use for building the project.       | No       | `Release`|
 | `test-verbosity`           | Set the verbosity of test results.                   | No       | `normal` |
 | `solution-path`            | Path to the solution file.                           | No       | `'.'`    |

--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ This GitHub Action is designed to provide a simple and effective way to build an
 
 ## Features
 
-- **🔨 Enhanced Error & Warning Reporting**: Structured parsing of build output with clear visual indicators
+- **🔨 Enhanced Error & Warning Reporting**: Reliable parsing of build output with clear visual indicators
 - **📊 Rich GitHub Actions Summary**: Detailed build and test results with collapsible sections and emoji status indicators
-- **💬 Automated PR Comments**: Posts build/test status directly to pull requests for immediate visibility
 - **🎯 GitHub Annotations**: Inline error and warning annotations with file/line information
-- **⚡ Structured Logging**: Uses MSBuild JSON output when available for reliable error detection
-- **🧪 Comprehensive Test Analysis**: Parses TRX files for detailed test failure information
-- **📁 Artifact Management**: Automatically uploads build logs, test results, and parsed error files
+- **🧪 Comprehensive Test Analysis**: Parses console output for detailed test failure information
 - **🔧 .NET Version Flexibility**: Uses any specified version of the .NET SDK
 - **⚙️ Configurable Build and Test Commands**: Allows for custom build configurations and test verbosity levels
+- **🚀 Zero External Dependencies**: Pure bash implementation with no external tool requirements
+- **📝 Self-Contained Reporting**: All reporting happens in-memory without file management overhead
 
 ### Visual Status Indicators
 
@@ -25,9 +24,9 @@ The action provides at-a-glance status information using emojis:
 ### Reporting Features
 
 - **GitHub Actions Summary**: Rich markdown summary with metrics tables and collapsible error/warning details
-- **PR Comments**: Automated comments on pull requests with top errors/warnings and quick status overview
 - **GitHub Annotations**: Inline file annotations for errors and warnings with precise line/column information
-- **Structured Data**: Exports build and test metrics for use in subsequent workflow steps
+- **Console Output**: Clear status messages with emoji indicators for quick visual assessment
+- **Environment Variables**: Exports build and test metrics for use in subsequent workflow steps
 
 ## Inputs
 
@@ -40,7 +39,6 @@ The action provides at-a-glance status information using emojis:
 | `solution-path`            | Path to the solution file.                           | No       | `'.'`    |
 | `additional-build-arguments`| Any additional arguments to include with your build command | No | `''` |
 | `additional-test-arguments`| Any additional arguments to include with your test command | No | `''` |
-| `create-pr-comment`        | Create a PR comment with build/test results          | No       | `true`   |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,30 @@ This GitHub Action is designed to provide a simple and effective way to build an
 
 ## Features
 
-- .NET Version Flexibility: Uses any specified version of the .NET SDK.
-- Configurable Build and Test Commands: Allows for custom build configurations and test verbosity levels.
+- **🔨 Enhanced Error & Warning Reporting**: Structured parsing of build output with clear visual indicators
+- **📊 Rich GitHub Actions Summary**: Detailed build and test results with collapsible sections and emoji status indicators
+- **💬 Automated PR Comments**: Posts build/test status directly to pull requests for immediate visibility
+- **🎯 GitHub Annotations**: Inline error and warning annotations with file/line information
+- **⚡ Structured Logging**: Uses MSBuild JSON output when available for reliable error detection
+- **🧪 Comprehensive Test Analysis**: Parses TRX files for detailed test failure information
+- **📁 Artifact Management**: Automatically uploads build logs, test results, and parsed error files
+- **🔧 .NET Version Flexibility**: Uses any specified version of the .NET SDK
+- **⚙️ Configurable Build and Test Commands**: Allows for custom build configurations and test verbosity levels
+
+### Visual Status Indicators
+
+The action provides at-a-glance status information using emojis:
+
+- 🟢 ✅ **SUCCESS** - No errors or warnings
+- 🟡 ⚠️ **SUCCESS WITH WARNINGS** - Build succeeded but has warnings
+- 🔴 ❌ **FAILED** - Build or tests failed
+
+### Reporting Features
+
+- **GitHub Actions Summary**: Rich markdown summary with metrics tables and collapsible error/warning details
+- **PR Comments**: Automated comments on pull requests with top errors/warnings and quick status overview
+- **GitHub Annotations**: Inline file annotations for errors and warnings with precise line/column information
+- **Structured Data**: Exports build and test metrics for use in subsequent workflow steps
 
 ## Inputs
 
@@ -18,6 +40,7 @@ This GitHub Action is designed to provide a simple and effective way to build an
 | `solution-path`            | Path to the solution file.                           | No       | `'.'`    |
 | `additional-build-arguments`| Any additional arguments to include with your build command | No | `''` |
 | `additional-test-arguments`| Any additional arguments to include with your test command | No | `''` |
+| `create-pr-comment`        | Create a PR comment with build/test results          | No       | `true`   |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This GitHub Action is designed to provide a simple and effective way to build an
 
 | Input                      | Description                                          | Required | Default  |
 |----------------------------|------------------------------------------------------|----------|----------|
-| `nuget-api-key` | The NuGet key set in your repo | Yes | '' |
+| `nuget-api-key` | The NuGet key set in your repo | Yes | `''` |
 |`dotnet-version`           | The .NET SDK version to use.                         | No       | `6.0`    |
 | `build-configuration`      | Configuration to use for building the project.       | No       | `Release`|
 | `test-verbosity`           | Set the verbosity of test results.                   | No       | `normal` |
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Run .NET CI Action
         uses: jmsudar/dotnet-continuous-integration@main
+        with:
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
 ```
 
 ### Customized Usage
@@ -56,6 +58,7 @@ jobs:
       - name: Run .NET CI Action
         uses: jmsudar/dotnet-continuous-integration@main
         with:
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
           dotnet-version: '7.0'
           build-configuration: 'Debug'
           test-verbosity: 'detailed'

--- a/action.yaml
+++ b/action.yaml
@@ -16,9 +16,30 @@ inputs:
     description: 'Set the verbosity of test results'
     required: false
     default: 'normal'
+  solution-path:
+    description: 'Path to the solution file'
+    required: false
+    default: '.'
+  additional-build-arguments:
+    description: 'Extra arguments to pass to dotnet build'
+    required: false
+    default: ''
+  additional-test-arguments:
+    description: 'Extra arguments to pass to dotnet test'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
+    # fast-fail if NUGET_API_KEY is not set, as CD will fail without it so the branch should not merge
+    - name: Check NUGET_API_KEY is set
+      shell: bash
+      run: |
+        if [[ -z "${{ secrets.NUGET_API_KEY }}" ]]; then
+          echo "::error::Error: NUGET_API_KEY is not set. Please ensure it is configured as a secret in your repository."
+          exit 1
+        fi
+
     - name: Checkout Code
       uses: actions/checkout@v4
 
@@ -28,13 +49,76 @@ runs:
         dotnet-version: ${{ inputs.dotnet-version }}
 
     - name: Restore dependencies
-      run: dotnet restore
       shell: bash
+      env:
+        SOLUTION_PATH: ${{ inputs.solution-path }}
+      run: dotnet restore ${{ env.SOLUTION_PATH }}
 
     - name: Build
-      run: dotnet build --no-restore --configuration ${{ inputs.build-configuration }}
       shell: bash
+      env:
+        BUILD_CONFIGURATION: ${{ inputs.build-configuration }}
+        SOLUTION_PATH: ${{ inputs.solution-path }}
+        ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
+      run: |
+        echo "::group::Build Output"
+        OUTPUT=$(dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.ADDITIONAL_BUILD_ARGUMENTS }} 2>&1)
+        echo "$OUTPUT"
+        echo "::endgroup::"
+
+        ERROR_COUNT=$(echo "$OUTPUT" | grep -cE 'error\s[A-Z]{4}[0-9]{4}:')
+        WARNING_COUNT=$(echo "$OUTPUT" | grep -cE 'warning\s[A-Z]{4}[0-9]{4}:')
+
+        if [[ "$ERROR_COUNT" -gt 0 ]]; then
+          echo "$OUTPUT" | grep -E 'error\s[A-Z]{4}[0-9]{4}:' | while read -r line; do
+            echo "::error::❌ $line"
+          done
+          echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
+          exit 1
+        elif [[ "$WARNING_COUNT" -gt 0 ]]; then
+          echo "$OUTPUT" | grep -E 'warning\s[A-Z]{4}[0-9]{4}:' | while read -r line; do
+            echo "::warning::⚠️ $line"
+          done
+          echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
+        else
+          echo "::notice::✅ Build succeeded with no warnings or errors"
+        fi
 
     - name: Run tests
-      run: dotnet test --no-build --configuration ${{ inputs.build-configuration }} --verbosity ${{ inputs.test-verbosity }}
       shell: bash
+      env:
+        BUILD_CONFIGURATION: ${{ inputs.build-configuration }}
+        SOLUTION_PATH: ${{ inputs.solution-path }}
+        TEST_VERBOSITY: ${{ inputs.test-verbosity }}
+        ADDITIONAL_TEST_ARGUMENTS: ${{ inputs.additional-test-arguments }}
+      run: |
+        echo "::group::Test Output"
+        OUTPUT=$(dotnet test ${{ env.SOLUTION_PATH }} --no-build --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity ${{ env.TEST_VERBOSITY }} ${{ env.ADDITIONAL_TEST_ARGUMENTS }} --logger "trx;LogFileName=test-results.trx" 2>&1 || true)
+        echo "$OUTPUT"
+        echo "::endgroup::"
+
+        PASSED=$(echo "$OUTPUT" | grep -oP 'Passed: \K[0-9]+')
+        FAILED=$(echo "$OUTPUT" | grep -oP 'Failed: \K[0-9]+')
+        SKIPPED=$(echo "$OUTPUT" | grep -oP 'Skipped: \K[0-9]+')
+
+        # Highlight failed tests by name
+        echo "$OUTPUT" | grep -A1 'Failed ' | grep -E '^\s*[^ ]+\s*\[.*\]' | while read -r line; do
+          TEST_NAME=$(echo "$line" | awk '{print $1}')
+          echo "::error::❌ Failed Test: $TEST_NAME"
+        done
+
+        # Highlight skipped tests by name
+        echo "$OUTPUT" | grep -A1 'Skipped ' | grep -E '^\s*[^ ]+\s*\[.*\]' | while read -r line; do
+          TEST_NAME=$(echo "$line" | awk '{print $1}')
+          echo "::warning::⚠️ Skipped Test: $TEST_NAME"
+        done
+
+        if [[ "$FAILED" -gt 0 ]]; then
+          echo "::error::❌ $FAILED test(s) failed"
+          exit 1
+        elif [[ "$SKIPPED" -gt 0 ]]; then
+          echo "::warning::⚠️ $SKIPPED test(s) skipped"
+          echo "::notice::✅ $PASSED test(s) passed"
+        else
+          echo "::notice::✅ All $PASSED test(s) passed"
+        fi

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ branding:
   icon: 'settings'
   color: 'green'
 inputs:
+  nuget-api-key:
+    description: 'NuGet API key for publishing packages'
+    required: true
+    default: ''
   dotnet-version:
     description: 'The .NET SDK version to use'
     required: false
@@ -33,9 +37,11 @@ runs:
   steps:
     # fast-fail if NUGET_API_KEY is not set, as CD will fail without it so the branch should not merge
     - name: Check NUGET_API_KEY is set
+      env:
+        NUGET_API_KEY: ${{ inputs.nuget-api-key }}
       shell: bash
       run: |
-        if [[ -z "${{ secrets.NUGET_API_KEY }}" ]]; then
+        if [[ -z "${NUGET_API_KEY}" ]]; then
           echo "::error::Error: NUGET_API_KEY is not set. Please ensure it is configured as a secret in your repository."
           exit 1
         fi
@@ -62,7 +68,7 @@ runs:
         ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
       run: |
         echo "::group::Build Output"
-        OUTPUT=$(dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.ADDITIONAL_BUILD_ARGUMENTS }} 2>&1)
+        OUTPUT=$(dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} 2>&1)
         echo "$OUTPUT"
         echo "::endgroup::"
 
@@ -93,7 +99,7 @@ runs:
         ADDITIONAL_TEST_ARGUMENTS: ${{ inputs.additional-test-arguments }}
       run: |
         echo "::group::Test Output"
-        OUTPUT=$(dotnet test ${{ env.SOLUTION_PATH }} --no-build --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity ${{ env.TEST_VERBOSITY }} ${{ env.ADDITIONAL_TEST_ARGUMENTS }} --logger "trx;LogFileName=test-results.trx" 2>&1 || true)
+        OUTPUT=$(dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} --logger "trx;LogFileName=test-results.trx" 2>&1 || true)
         echo "$OUTPUT"
         echo "::endgroup::"
 

--- a/action.yaml
+++ b/action.yaml
@@ -67,32 +67,49 @@ runs:
         SOLUTION_PATH: ${{ inputs.solution-path }}
         ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
       run: |
-        # Initialize variables
-        BUILD_SUCCESS=true
-        ERROR_COUNT=0
-        WARNING_COUNT=0
-        BUILD_LOG=$(mktemp)
+        # Capture build output to temp file
+        BUILD_OUTPUT=$(mktemp)
         
         echo "::group::Build Output"
         
-        # Run build and capture output
+        # Run build and capture all output
         set +e
         dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
-          --verbosity normal 2>&1 | tee "$BUILD_LOG"
+          --verbosity normal 2>&1 | tee "$BUILD_OUTPUT"
         BUILD_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Parse build results directly from log
-        # Count unique errors (improved pattern matching)
-        ERROR_COUNT=$(grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | wc -l)
+        # Process warnings using associative array for deduplication
+        declare -A warnings_map
+        while IFS=':' read -r key rest; do
+          if [[ -n "$key" && -n "$rest" ]]; then
+            # Clean up the key and value
+            key=$(echo "$key" | xargs)
+            rest=$(echo "$rest" | xargs)
+            warnings_map["$key"]="$rest"
+          fi
+        done < <(grep -i "warning" "$BUILD_OUTPUT" || true)
         
-        # Count unique warnings (improved pattern matching)
-        WARNING_COUNT=$(grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | wc -l)
+        WARNING_COUNT=${#warnings_map[@]}
         
-        # Determine build status
-        if [[ "$BUILD_EXIT_CODE" -ne 0 ]] || [[ "$ERROR_COUNT" -gt 0 ]]; then
+        # Process errors using associative array for deduplication
+        declare -A errors_map
+        while IFS=':' read -r key rest; do
+          if [[ -n "$key" && -n "$rest" ]]; then
+            # Clean up the key and value
+            key=$(echo "$key" | xargs)
+            rest=$(echo "$rest" | xargs)
+            errors_map["$key"]="$rest"
+          fi
+        done < <(grep -i "error" "$BUILD_OUTPUT" | grep -v "::error::" || true)
+        
+        ERROR_COUNT=${#errors_map[@]}
+        
+        # Determine build success
+        BUILD_SUCCESS=true
+        if [[ $BUILD_EXIT_CODE -ne 0 ]] || [[ $ERROR_COUNT -gt 0 ]]; then
           BUILD_SUCCESS=false
         fi
         
@@ -100,14 +117,13 @@ runs:
         echo "# 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        if [[ "$BUILD_SUCCESS" == "true" ]]; then
-          if [[ "$WARNING_COUNT" -gt 0 ]]; then
-            echo "🟡 **Build Status:** ⚠️ SUCCESS WITH WARNINGS" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "🟢 **Build Status:** ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
-          fi
-        else
+        # Build status with emoji indicators
+        if [[ $ERROR_COUNT -gt 0 ]]; then
           echo "🔴 **Build Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
+        elif [[ $WARNING_COUNT -gt 0 ]]; then
+          echo "🟡 **Build Status:** ⚠️ SUCCESS WITH WARNINGS" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "🟢 **Build Status:** ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
         fi
         
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -117,79 +133,55 @@ runs:
         echo "| 🟡 Warnings | $WARNING_COUNT |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Add error details if any (limit to top 10)
-        if [[ "$ERROR_COUNT" -gt 0 ]]; then
+        # Add error details if any
+        if [[ $ERROR_COUNT -gt 0 ]]; then
           echo "<details>" >> $GITHUB_STEP_SUMMARY
           echo "<summary>🔴 Build Errors ($ERROR_COUNT)</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          for key in "${!errors_map[@]}"; do
+            echo "- **$key**: ${errors_map[$key]}" >> $GITHUB_STEP_SUMMARY
+          done
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Create GitHub annotations for errors (limit to top 10)
-          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 | while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Try to extract file path, line, column, and message
-              if [[ "$line" =~ ^[[:space:]]*([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*error[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
-                local file_path="${BASH_REMATCH[1]}"
-                local line_num="${BASH_REMATCH[2]}"
-                local col_num="${BASH_REMATCH[3]}"
-                local code="${BASH_REMATCH[4]}"
-                local message="${BASH_REMATCH[5]}"
-                
-                # Convert to relative path
-                local rel_path=$(echo "$file_path" | sed 's|.*/||')
-                echo "::error file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
-              else
-                echo "::error::${line}"
-              fi
-            fi
-          done
         fi
         
-        # Add warning details if any (limit to top 10)
-        if [[ "$WARNING_COUNT" -gt 0 ]]; then
+        # Add warning details if any
+        if [[ $WARNING_COUNT -gt 0 ]]; then
           echo "<details>" >> $GITHUB_STEP_SUMMARY
           echo "<summary>🟡 Build Warnings ($WARNING_COUNT)</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          for key in "${!warnings_map[@]}"; do
+            echo "- **$key**: ${warnings_map[$key]}" >> $GITHUB_STEP_SUMMARY
+          done
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Create GitHub annotations for warnings (limit to top 10)
-          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 | while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Try to extract file path, line, column, and message
-              if [[ "$line" =~ ^[[:space:]]*([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*warning[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
-                local file_path="${BASH_REMATCH[1]}"
-                local line_num="${BASH_REMATCH[2]}"
-                local col_num="${BASH_REMATCH[3]}"
-                local code="${BASH_REMATCH[4]}"
-                local message="${BASH_REMATCH[5]}"
-                
-                # Convert to relative path
-                local rel_path=$(echo "$file_path" | sed 's|.*/||')
-                echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
-              else
-                echo "::warning::${line}"
-              fi
-            fi
-          done
         fi
         
+        # Create GitHub annotations for errors
+        for key in "${!errors_map[@]}"; do
+          echo "::error::$key: ${errors_map[$key]}"
+        done
+        
+        # Create GitHub annotations for warnings
+        for key in "${!warnings_map[@]}"; do
+          echo "::warning::$key: ${warnings_map[$key]}"
+        done
+        
         # Output final status messages
-        if [[ "$BUILD_SUCCESS" == "false" ]]; then
-          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+        if [[ $BUILD_SUCCESS == false ]]; then
+          if [[ $WARNING_COUNT -gt 0 ]]; then
             echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
           else
             echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
           fi
         else
-          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+          if [[ $WARNING_COUNT -gt 0 ]]; then
             echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
           else
             echo "::notice::✅ Build succeeded with no errors or warnings"
@@ -202,10 +194,10 @@ runs:
         echo "BUILD_WARNING_COUNT=$WARNING_COUNT" >> $GITHUB_ENV
         
         # Clean up temp file
-        rm -f "$BUILD_LOG"
+        rm -f "$BUILD_OUTPUT"
         
         # Exit with error if build failed
-        if [[ "$BUILD_SUCCESS" == "false" ]]; then
+        if [[ $BUILD_SUCCESS == false ]]; then
           exit 1
         fi
 
@@ -217,41 +209,35 @@ runs:
         TEST_VERBOSITY: ${{ inputs.test-verbosity }}
         ADDITIONAL_TEST_ARGUMENTS: ${{ inputs.additional-test-arguments }}
       run: |
-        # Initialize test variables
-        TEST_SUCCESS=true
-        TEST_LOG=$(mktemp)
-        PASSED=0
-        FAILED=0
-        SKIPPED=0
-        TOTAL=0
+        # Capture test output to temp file
+        TEST_OUTPUT=$(mktemp)
         
         echo "::group::Test Output"
         
-        # Run tests and capture output
+        # Run tests and capture all output
         set +e
         dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} \
           --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} \
-          --logger "console;verbosity=detailed" 2>&1 | tee "$TEST_LOG"
+          --logger "console;verbosity=detailed" 2>&1 | tee "$TEST_OUTPUT"
         TEST_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Parse test results from console output
-        # Try multiple patterns to catch different dotnet output formats
-        PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-        FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-        SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        # Parse test results from console output using simple grep
+        PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_OUTPUT" | tail -1 || echo "0")
+        FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_OUTPUT" | tail -1 || echo "0")
+        SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_OUTPUT" | tail -1 || echo "0")
         
-        # Alternative parsing for different output formats
-        if [[ "$PASSED" == "0" ]] && [[ "$FAILED" == "0" ]] && [[ "$SKIPPED" == "0" ]]; then
+        # Alternative parsing patterns for different dotnet output formats
+        if [[ "$PASSED" == "0" && "$FAILED" == "0" && "$SKIPPED" == "0" ]]; then
           # Try alternative patterns
-          PASSED=$(grep -oP 'Passed!\s*-\s*Failed:\s*0,\s*Passed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
-          FAILED=$(grep -oP 'Failed!\s*-\s*Failed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
+          PASSED=$(grep -oP 'Passed!\s*-\s*Failed:\s*0,\s*Passed:\s*\K[0-9]+' "$TEST_OUTPUT" || echo "0")
+          FAILED=$(grep -oP 'Failed!\s*-\s*Failed:\s*\K[0-9]+' "$TEST_OUTPUT" || echo "0")
           
-          # Try yet another pattern
-          if [[ "$PASSED" == "0" ]] && [[ "$FAILED" == "0" ]]; then
-            TOTAL_LINE=$(grep -E "Total tests:|Tests run:" "$TEST_LOG" | tail -1 || echo "")
+          # Try yet another pattern for summary lines
+          if [[ "$PASSED" == "0" && "$FAILED" == "0" ]]; then
+            TOTAL_LINE=$(grep -E "Total tests:|Tests run:" "$TEST_OUTPUT" | tail -1 || echo "")
             if [[ -n "$TOTAL_LINE" ]]; then
               PASSED=$(echo "$TOTAL_LINE" | grep -oP 'Passed:\s*\K[0-9]+' || echo "0")
               FAILED=$(echo "$TOTAL_LINE" | grep -oP 'Failed:\s*\K[0-9]+' || echo "0")
@@ -262,8 +248,9 @@ runs:
         
         TOTAL=$((PASSED + FAILED + SKIPPED))
         
-        # Determine test status
-        if [[ "$TEST_EXIT_CODE" -ne 0 ]] || [[ "$FAILED" -gt 0 ]]; then
+        # Determine test success
+        TEST_SUCCESS=true
+        if [[ $TEST_EXIT_CODE -ne 0 ]] || [[ $FAILED -gt 0 ]]; then
           TEST_SUCCESS=false
         fi
         
@@ -272,14 +259,13 @@ runs:
         echo "# 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        if [[ "$TEST_SUCCESS" == "true" ]]; then
-          if [[ "$SKIPPED" -gt 0 ]]; then
-            echo "🟡 **Test Status:** ⚠️ PASSED WITH SKIPPED TESTS" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "🟢 **Test Status:** ✅ ALL PASSED" >> $GITHUB_STEP_SUMMARY
-          fi
-        else
+        # Test status with emoji indicators
+        if [[ $TEST_SUCCESS == false ]]; then
           echo "🔴 **Test Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
+        elif [[ $SKIPPED -gt 0 ]]; then
+          echo "🟡 **Test Status:** ⚠️ PASSED WITH SKIPPED TESTS" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "🟢 **Test Status:** ✅ ALL PASSED" >> $GITHUB_STEP_SUMMARY
         fi
         
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -291,16 +277,15 @@ runs:
         echo "| ⏭️ Skipped | $SKIPPED |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Add failed test details if any
-        if [[ "$FAILED" -gt 0 ]]; then
+        # Add failed test details if any (simple approach for now)
+        if [[ $FAILED -gt 0 ]]; then
           echo "<details>" >> $GITHUB_STEP_SUMMARY
           echo "<summary>❌ Failed Tests ($FAILED)</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           
-          # Extract failed test names from output (multiple patterns)
-          grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 >> $GITHUB_STEP_SUMMARY || \
-          grep -E "^\s*X\s+" "$TEST_LOG" | head -10 >> $GITHUB_STEP_SUMMARY || \
+          # Extract failed test information using simple grep patterns
+          grep -E "(FAIL|Failed|✗)" "$TEST_OUTPUT" | grep -v "Failed:" | head -10 >> $GITHUB_STEP_SUMMARY || \
           echo "Failed test details not available in this format" >> $GITHUB_STEP_SUMMARY
           
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -308,7 +293,7 @@ runs:
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # Create GitHub annotations for failed tests
-          grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 | while IFS= read -r line; do
+          grep -E "(FAIL|Failed|✗)" "$TEST_OUTPUT" | grep -v "Failed:" | head -10 | while IFS= read -r line; do
             if [[ -n "$line" ]]; then
               echo "::error::❌ Failed Test: $line"
             fi
@@ -316,12 +301,12 @@ runs:
         fi
         
         # Output final test status messages
-        if [[ "$TEST_SUCCESS" == "false" ]]; then
+        if [[ $TEST_SUCCESS == false ]]; then
           echo "::error::❌ $FAILED test(s) failed out of $TOTAL total tests"
         else
-          if [[ "$SKIPPED" -gt 0 ]]; then
+          if [[ $SKIPPED -gt 0 ]]; then
             echo "::warning::⚠️ All tests passed but $SKIPPED test(s) were skipped"
-          elif [[ "$TOTAL" -gt 0 ]]; then
+          elif [[ $TOTAL -gt 0 ]]; then
             echo "::notice::✅ All $PASSED test(s) passed"
           else
             echo "::warning::⚠️ No tests found to execute"
@@ -336,10 +321,10 @@ runs:
         echo "TEST_SKIPPED=$SKIPPED" >> $GITHUB_ENV
         
         # Clean up temp file
-        rm -f "$TEST_LOG"
+        rm -f "$TEST_OUTPUT"
         
         # Exit with error if tests failed
-        if [[ "$TEST_SUCCESS" == "false" ]]; then
+        if [[ $TEST_SUCCESS == false ]]; then
           exit 1
         fi
 
@@ -356,7 +341,7 @@ runs:
         BUILD_SUCCESS="${BUILD_SUCCESS:-false}"
         TEST_SUCCESS="${TEST_SUCCESS:-false}"
         
-        if [[ "$BUILD_SUCCESS" == "true" ]] && [[ "$TEST_SUCCESS" == "true" ]]; then
+        if [[ "$BUILD_SUCCESS" == "true" && "$TEST_SUCCESS" == "true" ]]; then
           echo "🎉 **Overall Status: SUCCESS** ✅" >> $GITHUB_STEP_SUMMARY
           echo "::notice::🎉 CI pipeline completed successfully!"
         else

--- a/action.yaml
+++ b/action.yaml
@@ -181,6 +181,28 @@ runs:
                  grep -v "::warning::" | \
                  head -50 || true)
         
+        # Pattern 4: Look for CS0219 specifically (unused variable warning)
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Extract a reasonable key from the line
+            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "CS0219" "$BUILD_OUTPUT" | head -10 || true)
+        
+        # Pattern 5: Look for any suppressed warnings or warning-related output
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Use the full line as key for suppressed warnings
+            key=$(echo "$line" | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "(nowarn|suppress.*warning)" "$BUILD_OUTPUT" | head -5 || true)
+        
         WARNING_COUNT=${#warnings_map[@]}
         
         # Debug: Show what warnings were found
@@ -193,6 +215,10 @@ runs:
           done
         else
           echo "No warnings found with any pattern"
+          echo "Checking if CS0219 appears anywhere in output:"
+          grep -i "CS0219" "$BUILD_OUTPUT" || echo "CS0219 not found"
+          echo "Checking warning suppression:"
+          grep -i "nowarn" "$BUILD_OUTPUT" || echo "No nowarn found"
         fi
         echo "::endgroup::"
         

--- a/action.yaml
+++ b/action.yaml
@@ -105,10 +105,34 @@ runs:
         
         ERROR_COUNT=${#errors_map[@]}
         
+        # Debug: Show sample of build output for troubleshooting
+        echo "::group::Debug - Build Output Sample (first 50 lines)"
+        head -50 "$BUILD_OUTPUT" || true
+        echo "::endgroup::"
+        
+        echo "::group::Debug - Lines containing 'warning'"
+        grep -i "warning" "$BUILD_OUTPUT" | head -20 || echo "No lines containing 'warning' found"
+        echo "::endgroup::"
+        
+        echo "::group::Debug - Raw grep patterns test"
+        echo "Testing Pattern 1 (strict MSBuild):"
+        grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 1"
+        echo ""
+        echo "Testing Pattern 2 (broader):"
+        grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 2"
+        echo ""
+        echo "Testing Pattern 3 (broadest):"
+        grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 3"
+        echo ""
+        echo "File size and line count:"
+        wc -l "$BUILD_OUTPUT" || echo "Could not count lines"
+        echo "::endgroup::"
+        
         # Process warnings using associative array for deduplication
-        # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
-        # Exclude compiler command lines and GitHub Actions annotations
+        # Use multiple patterns to catch different warning formats
         declare -A warnings_map
+        
+        # Pattern 1: Standard MSBuild format: file(line,col): warning CODE: message
         while IFS=':' read -r full_line rest; do
           if [[ -n "$full_line" && -n "$rest" ]]; then
             # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
@@ -127,7 +151,50 @@ runs:
                  grep -v "/errorreport:" | \
                  grep -v "::warning::" || true)
         
+        # Pattern 2: Broader warning pattern (fallback)
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Create a unique key from the warning
+            key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              rest=$(echo "$rest" | xargs)
+              warnings_map["$key"]="$rest"
+            fi
+          fi
+        done < <(grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" || true)
+        
+        # Pattern 3: Even broader - any line with "warning" and a code
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Extract a reasonable key from the line
+            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" | \
+                 head -50 || true)
+        
         WARNING_COUNT=${#warnings_map[@]}
+        
+        # Debug: Show what warnings were found
+        echo "::group::Debug - Warnings Found ($WARNING_COUNT)"
+        if [[ $WARNING_COUNT -gt 0 ]]; then
+          for key in "${!warnings_map[@]}"; do
+            echo "Key: $key"
+            echo "Value: ${warnings_map[$key]}"
+            echo "---"
+          done
+        else
+          echo "No warnings found with any pattern"
+        fi
+        echo "::endgroup::"
         
         # Determine build success
         BUILD_SUCCESS=true

--- a/action.yaml
+++ b/action.yaml
@@ -107,56 +107,34 @@ runs:
         
         
         # Process warnings using associative array for deduplication
-        # Focus on actual MSBuild warning messages, not compiler command lines
+        # Use similar approach to errors but for warnings
         declare -A warnings_map
-        
-        # Enhanced filtering function to exclude compiler commands and noise
-        filter_compiler_noise() {
-          grep -v "/usr/share/dotnet/dotnet exec" | \
-          grep -v "/usr/share/dotnet/sdk/" | \
-          grep -v "Roslyn/bincore/csc.dll" | \
-          grep -v "/errorreport:" | \
-          grep -v "/nowarn:" | \
-          grep -v "/reference:" | \
-          grep -v "/define:" | \
-          grep -v "/analyzer:" | \
-          grep -v "::warning::" | \
-          grep -v "^[[:space:]]*$"
-        }
-        
-        # Pattern 1: Standard MSBuild format: file(line,col): warning CODE: message
-        # This is the most reliable pattern for actual warnings
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Extract file and location for the key
-            if [[ "$line" =~ ([^/]+\([0-9]+,[0-9]+\)):[[:space:]]*warning[[:space:]]+([A-Z]{2}[0-9]{4}):[[:space:]]*(.+) ]]; then
-              file_location="${BASH_REMATCH[1]}"
-              warning_code="${BASH_REMATCH[2]}"
-              warning_message="${BASH_REMATCH[3]}"
-              key="$file_location"
-              warnings_map["$key"]="warning $warning_code: $warning_message"
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Skip compiler command lines that contain warning-related text
+            if [[ "$full_line" =~ /usr/share/dotnet/dotnet[[:space:]]exec ]] || \
+               [[ "$full_line" =~ Roslyn/bincore/csc\.dll ]] || \
+               [[ "$rest" =~ /nowarn: ]] || \
+               [[ "$rest" =~ /reference: ]] || \
+               [[ "$rest" =~ /define: ]]; then
+              continue
             fi
+            
+            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
+            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
+            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
+              key="${BASH_REMATCH[1]}"
+            else
+              # Fallback: clean up the full line and use as key
+              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            fi
+            rest=$(echo "$rest" | xargs)
+            warnings_map["$key"]="$rest"
           fi
-        done < <(grep -E "\([0-9]+,[0-9]+\):[[:space:]]*warning[[:space:]]+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | filter_compiler_noise || true)
-        
-        # Pattern 2: Alternative format - look for warnings in project files or other contexts
-        # Only if we haven't found warnings with Pattern 1
-        if [[ ${#warnings_map[@]} -eq 0 ]]; then
-          while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Look for warning code and extract meaningful parts
-              if [[ "$line" =~ warning[[:space:]]+([A-Z]{2}[0-9]{4}):[[:space:]]*(.+) ]]; then
-                warning_code="${BASH_REMATCH[1]}"
-                warning_message="${BASH_REMATCH[2]}"
-                # Use warning code as key to avoid duplicates
-                key="$warning_code"
-                if [[ -z "${warnings_map[$key]}" ]]; then
-                  warnings_map["$key"]="warning $warning_code: $warning_message"
-                fi
-              fi
-            fi
-          done < <(grep -iE "warning[[:space:]]+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | filter_compiler_noise | head -20 || true)
-        fi
+        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" || true)
         
         WARNING_COUNT=${#warnings_map[@]}
         

--- a/action.yaml
+++ b/action.yaml
@@ -84,9 +84,23 @@ runs:
         echo "## 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Parse build output for errors and warnings
-        ERROR_COUNT=$(grep -cE 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
-        WARNING_COUNT=$(grep -cE 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
+        # Parse build output for errors and warnings with multiple patterns
+        # Try different patterns to catch various .NET warning/error formats
+        ERROR_COUNT=$(grep -ciE '(error\s[A-Z]+[0-9]+:|error:|^\s*error\s)' "$BUILD_LOG" || echo "0")
+        WARNING_COUNT=$(grep -ciE '(warning\s[A-Z]+[0-9]+:|warning:|^\s*warning\s)' "$BUILD_LOG" || echo "0")
+        
+        # Extract unique errors and warnings for display using broader patterns
+        UNIQUE_ERRORS=$(grep -iE '(error\s[A-Z]+[0-9]+:|error:|^\s*error\s)' "$BUILD_LOG" | sort -u || true)
+        UNIQUE_WARNINGS=$(grep -iE '(warning\s[A-Z]+[0-9]+:|warning:|^\s*warning\s)' "$BUILD_LOG" | sort -u || true)
+        
+        # Debug output to help troubleshoot warning detection
+        echo "::debug::Found $ERROR_COUNT errors and $WARNING_COUNT warnings in build log"
+        if [[ "$WARNING_COUNT" -gt 0 ]]; then
+          echo "::debug::Sample warnings found:"
+          echo "$UNIQUE_WARNINGS" | head -3 | while read -r line; do
+            echo "::debug::  $line"
+          done
+        fi
         
         if [[ "$BUILD_EXIT_CODE" -ne 0 ]] || [[ "$ERROR_COUNT" -gt 0 ]]; then
           echo "❌ **Build Status:** FAILED" >> $GITHUB_STEP_SUMMARY
@@ -100,17 +114,39 @@ runs:
           if [[ "$ERROR_COUNT" -gt 0 ]]; then
             echo "### ❌ Build Errors" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | head -10 >> $GITHUB_STEP_SUMMARY
+            echo "$UNIQUE_ERRORS" | head -10 >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Also output as GitHub annotations
-            grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | while read -r line; do
-              echo "::error::❌ $line"
+            # Output as GitHub annotations (deduplicated)
+            echo "$UNIQUE_ERRORS" | head -10 | while read -r line; do
+              if [[ -n "$line" ]]; then
+                echo "::error::❌ $line"
+              fi
             done
           fi
           
-          echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
+          # Show warnings in summary if any (deduplicated)
+          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+            echo "### ⚠️ Build Warnings" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$UNIQUE_WARNINGS" | head -10 >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Output as GitHub annotations (deduplicated)
+            echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
+              if [[ -n "$line" ]]; then
+                echo "::warning::⚠️ $line"
+              fi
+            done
+          fi
+          
+          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+            echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
+          else
+            echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
+          fi
           exit 1
         else
           echo "✅ **Build Status:** SUCCESS" >> $GITHUB_STEP_SUMMARY
@@ -122,13 +158,15 @@ runs:
           if [[ "$WARNING_COUNT" -gt 0 ]]; then
             echo "### ⚠️ Build Warnings" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | head -10 >> $GITHUB_STEP_SUMMARY
+            echo "$UNIQUE_WARNINGS" | head -10 >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Also output as GitHub annotations
-            grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | while read -r line; do
-              echo "::warning::⚠️ $line"
+            # Output as GitHub annotations (deduplicated)
+            echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
+              if [[ -n "$line" ]]; then
+                echo "::warning::⚠️ $line"
+              fi
             done
             echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
           else

--- a/action.yaml
+++ b/action.yaml
@@ -105,21 +105,36 @@ runs:
         
         ERROR_COUNT=${#errors_map[@]}
         
+        # Debug: Show sample of build output for troubleshooting
+        echo "::group::Debug - Build Output Sample (first 50 lines)"
+        head -50 "$BUILD_OUTPUT" || true
+        echo "::endgroup::"
+        
+        echo "::group::Debug - Lines containing 'warning'"
+        grep -i "warning" "$BUILD_OUTPUT" | head -20 || echo "No lines containing 'warning' found"
+        echo "::endgroup::"
+        
+        echo "::group::Debug - Raw grep patterns test"
+        echo "Testing Pattern 1 (strict MSBuild):"
+        grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 1"
+        echo ""
+        echo "Testing Pattern 2 (broader):"
+        grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 2"
+        echo ""
+        echo "Testing Pattern 3 (broadest):"
+        grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 3"
+        echo ""
+        echo "File size and line count:"
+        wc -l "$BUILD_OUTPUT" || echo "Could not count lines"
+        echo "::endgroup::"
         
         # Process warnings using associative array for deduplication
-        # Use similar approach to errors but for warnings
+        # Use multiple patterns to catch different warning formats
         declare -A warnings_map
+        
+        # Pattern 1: Standard MSBuild format: file(line,col): warning CODE: message
         while IFS=':' read -r full_line rest; do
           if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Skip compiler command lines that contain warning-related text
-            if [[ "$full_line" =~ /usr/share/dotnet/dotnet[[:space:]]exec ]] || \
-               [[ "$full_line" =~ Roslyn/bincore/csc\.dll ]] || \
-               [[ "$rest" =~ /nowarn: ]] || \
-               [[ "$rest" =~ /reference: ]] || \
-               [[ "$rest" =~ /define: ]]; then
-              continue
-            fi
-            
             # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
             # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
             if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
@@ -136,8 +151,76 @@ runs:
                  grep -v "/errorreport:" | \
                  grep -v "::warning::" || true)
         
+        # Pattern 2: Broader warning pattern (fallback)
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Create a unique key from the warning
+            key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              rest=$(echo "$rest" | xargs)
+              warnings_map["$key"]="$rest"
+            fi
+          fi
+        done < <(grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" || true)
+        
+        # Pattern 3: Even broader - any line with "warning" and a code
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Extract a reasonable key from the line
+            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" | \
+                 head -50 || true)
+        
+        # Pattern 4: Look for CS0219 specifically (unused variable warning)
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Extract a reasonable key from the line
+            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "CS0219" "$BUILD_OUTPUT" | head -10 || true)
+        
+        # Pattern 5: Look for any suppressed warnings or warning-related output
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            # Use the full line as key for suppressed warnings
+            key=$(echo "$line" | xargs)
+            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
+              warnings_map["$key"]="$line"
+            fi
+          fi
+        done < <(grep -iE "(nowarn|suppress.*warning)" "$BUILD_OUTPUT" | head -5 || true)
+        
         WARNING_COUNT=${#warnings_map[@]}
         
+        # Debug: Show what warnings were found
+        echo "::group::Debug - Warnings Found ($WARNING_COUNT)"
+        if [[ $WARNING_COUNT -gt 0 ]]; then
+          for key in "${!warnings_map[@]}"; do
+            echo "Key: $key"
+            echo "Value: ${warnings_map[$key]}"
+            echo "---"
+          done
+        else
+          echo "No warnings found with any pattern"
+          echo "Checking if CS0219 appears anywhere in output:"
+          grep -i "CS0219" "$BUILD_OUTPUT" || echo "CS0219 not found"
+          echo "Checking warning suppression:"
+          grep -i "nowarn" "$BUILD_OUTPUT" || echo "No nowarn found"
+        fi
+        echo "::endgroup::"
         
         # Determine build success
         BUILD_SUCCESS=true

--- a/action.yaml
+++ b/action.yaml
@@ -84,17 +84,26 @@ runs:
         echo "## 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Parse build output for errors and warnings with precise patterns
-        # Use more specific patterns to avoid false matches
-        ERROR_COUNT=$(grep -cE 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
-        WARNING_COUNT=$(grep -cE 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
-        
-        # Extract unique errors and warnings for display
+        # Parse build output for errors and warnings with improved patterns
+        # Extract unique errors and warnings first, then count them
         UNIQUE_ERRORS=$(grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u || true)
-        UNIQUE_WARNINGS=$(grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u || true)
+        UNIQUE_WARNINGS=$(grep -E '(warning\s[A-Z]{2}[0-9]{4}:|warning\s[A-Z]+[0-9]+:|\bwarning\b.*:)' "$BUILD_LOG" | sort -u || true)
         
-        # Debug output to help troubleshoot warning detection
-        echo "::debug::Found $ERROR_COUNT errors and $WARNING_COUNT warnings in build log"
+        # Count unique errors and warnings
+        if [[ -n "$UNIQUE_ERRORS" ]]; then
+          ERROR_COUNT=$(echo "$UNIQUE_ERRORS" | wc -l)
+        else
+          ERROR_COUNT=0
+        fi
+        
+        if [[ -n "$UNIQUE_WARNINGS" ]]; then
+          WARNING_COUNT=$(echo "$UNIQUE_WARNINGS" | wc -l)
+        else
+          WARNING_COUNT=0
+        fi
+        
+        # Debug output to help troubleshoot detection
+        echo "::debug::Found $ERROR_COUNT unique errors and $WARNING_COUNT unique warnings in build log"
         echo "::debug::Checking for any lines containing 'warning' (case insensitive):"
         grep -i 'warning' "$BUILD_LOG" | head -5 || echo "::debug::No lines containing 'warning' found"
         
@@ -121,10 +130,21 @@ runs:
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Output as GitHub annotations (deduplicated)
+            # Output as GitHub annotations with file/line info when possible
             echo "$UNIQUE_ERRORS" | head -10 | while read -r line; do
               if [[ -n "$line" ]]; then
-                echo "::error::❌ $line"
+                # Try to extract file path and line number for better annotations
+                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*error.*:(.*)$ ]]; then
+                  file_path="${BASH_REMATCH[1]}"
+                  line_num="${BASH_REMATCH[2]}"
+                  col_num="${BASH_REMATCH[3]}"
+                  error_msg="${BASH_REMATCH[4]}"
+                  # Convert absolute path to relative if possible
+                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
+                  echo "::error file=${rel_path},line=${line_num},col=${col_num}::${error_msg}"
+                else
+                  echo "::error::$line"
+                fi
               fi
             done
           fi
@@ -137,18 +157,30 @@ runs:
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Output as GitHub annotations (deduplicated)
+            # Output as GitHub annotations with file/line info when possible
             echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
               if [[ -n "$line" ]]; then
-                echo "::warning::⚠️ $line"
+                # Try to extract file path and line number for better annotations
+                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*warning.*:(.*)$ ]]; then
+                  file_path="${BASH_REMATCH[1]}"
+                  line_num="${BASH_REMATCH[2]}"
+                  col_num="${BASH_REMATCH[3]}"
+                  warning_msg="${BASH_REMATCH[4]}"
+                  # Convert absolute path to relative if possible
+                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
+                  echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${warning_msg}"
+                else
+                  echo "::warning::$line"
+                fi
               fi
             done
           fi
           
+          # Single summary error message
           if [[ "$WARNING_COUNT" -gt 0 ]]; then
-            echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
+            echo "::error::Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
           else
-            echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
+            echo "::error::Build failed with $ERROR_COUNT error(s)"
           fi
           exit 1
         else
@@ -165,13 +197,24 @@ runs:
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             
-            # Output as GitHub annotations (deduplicated)
+            # Output as GitHub annotations with file/line info when possible
             echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
               if [[ -n "$line" ]]; then
-                echo "::warning::⚠️ $line"
+                # Try to extract file path and line number for better annotations
+                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*warning.*:(.*)$ ]]; then
+                  file_path="${BASH_REMATCH[1]}"
+                  line_num="${BASH_REMATCH[2]}"
+                  col_num="${BASH_REMATCH[3]}"
+                  warning_msg="${BASH_REMATCH[4]}"
+                  # Convert absolute path to relative if possible
+                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
+                  echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${warning_msg}"
+                else
+                  echo "::warning::$line"
+                fi
               fi
             done
-            echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
+            echo "::warning::Build succeeded with $WARNING_COUNT warning(s)"
           else
             echo "::notice::✅ Build succeeded with no warnings or errors"
           fi
@@ -285,16 +328,17 @@ runs:
       with:
         name: build-and-test-logs
         path: |
-          ${{ env.BUILD_LOG_PATH }}
-          ${{ env.TEST_LOG_PATH }}
-          ${{ env.TEST_RESULTS_PATH }}
+          build-output.log
+          test-output.log
+          test-results.trx
         retention-days: 30
+        if-no-files-found: ignore
 
     - name: Publish Test Results
       uses: dorny/test-reporter@v1
       if: always()
       with:
         name: .NET Test Results
-        path: ${{ env.TEST_RESULTS_PATH }}
+        path: test-results.trx
         reporter: dotnet-trx
         fail-on-error: false

--- a/action.yaml
+++ b/action.yaml
@@ -32,10 +32,6 @@ inputs:
     description: 'Extra arguments to pass to dotnet test'
     required: false
     default: ''
-  create-pr-comment:
-    description: 'Create a PR comment with build/test results'
-    required: false
-    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -75,159 +71,115 @@ runs:
         BUILD_SUCCESS=true
         ERROR_COUNT=0
         WARNING_COUNT=0
-        BUILD_LOG="build-output.log"
-        BUILD_JSON="build-results.json"
-        
-        # Function to parse build results from structured output
-        parse_build_results() {
-          local log_file="$1"
-          local json_file="$2"
-          
-          # Try to parse JSON output first (more reliable)
-          if [[ -f "$json_file" ]] && command -v jq >/dev/null 2>&1; then
-            # Parse JSON structured output
-            ERROR_COUNT=$(jq -r '[.[] | select(.level == "error")] | length' "$json_file" 2>/dev/null || echo "0")
-            WARNING_COUNT=$(jq -r '[.[] | select(.level == "warning")] | length' "$json_file" 2>/dev/null || echo "0")
-            
-            # Extract unique errors
-            if [[ "$ERROR_COUNT" -gt 0 ]]; then
-              jq -r '.[] | select(.level == "error") | "\(.file // "")(\(.line // ""),\(.column // "")): error \(.code // ""): \(.message // "")"' "$json_file" 2>/dev/null | sort -u > errors.txt
-            fi
-            
-            # Extract unique warnings  
-            if [[ "$WARNING_COUNT" -gt 0 ]]; then
-              jq -r '.[] | select(.level == "warning") | "\(.file // "")(\(.line // ""),\(.column // "")): warning \(.code // ""): \(.message // "")"' "$json_file" 2>/dev/null | sort -u > warnings.txt
-            fi
-          else
-            # Fallback to improved text parsing
-            # Extract errors with improved pattern matching
-            grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$log_file" | sort -u > errors.txt 2>/dev/null || touch errors.txt
-            ERROR_COUNT=$(wc -l < errors.txt)
-            
-            # Extract warnings with improved pattern matching
-            grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$log_file" | sort -u > warnings.txt 2>/dev/null || touch warnings.txt
-            WARNING_COUNT=$(wc -l < warnings.txt)
-          fi
-        }
-        
-        # Function to create GitHub annotations
-        create_annotations() {
-          local type="$1"
-          local file="$2"
-          local limit="${3:-10}"
-          
-          if [[ -f "$file" ]] && [[ -s "$file" ]]; then
-            head -n "$limit" "$file" | while IFS= read -r line; do
-              if [[ -n "$line" ]]; then
-                # Extract file path, line, column, and message
-                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*${type}[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
-                  local file_path="${BASH_REMATCH[1]}"
-                  local line_num="${BASH_REMATCH[2]}"
-                  local col_num="${BASH_REMATCH[3]}"
-                  local code="${BASH_REMATCH[4]}"
-                  local message="${BASH_REMATCH[5]}"
-                  
-                  # Convert to relative path
-                  local rel_path=$(echo "$file_path" | sed 's|.*/||')
-                  echo "::${type} file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
-                else
-                  echo "::${type}::${line}"
-                fi
-              fi
-            done
-          fi
-        }
-        
-        # Function to generate summary content
-        generate_summary() {
-          local build_status="$1"
-          local error_count="$2"
-          local warning_count="$3"
-          
-          echo "# 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ "$build_status" == "success" ]]; then
-            if [[ "$warning_count" -gt 0 ]]; then
-              echo "🟡 **Build Status:** ⚠️ SUCCESS WITH WARNINGS" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "🟢 **Build Status:** ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "🔴 **Build Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 🔴 Errors | $error_count |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🟡 Warnings | $warning_count |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Add error details if any
-          if [[ "$error_count" -gt 0 ]] && [[ -f "errors.txt" ]]; then
-            echo "<details>" >> $GITHUB_STEP_SUMMARY
-            echo "<summary>🔴 Build Errors ($error_count)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            head -20 errors.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          # Add warning details if any
-          if [[ "$warning_count" -gt 0 ]] && [[ -f "warnings.txt" ]]; then
-            echo "<details>" >> $GITHUB_STEP_SUMMARY
-            echo "<summary>🟡 Build Warnings ($warning_count)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            head -20 warnings.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-        }
+        BUILD_LOG=$(mktemp)
         
         echo "::group::Build Output"
         
-        # Run build with structured logging
+        # Run build and capture output
         set +e
-        if command -v jq >/dev/null 2>&1; then
-          # Use JSON logger if jq is available
-          dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
-            --logger "console;verbosity=minimal" \
-            --logger "json;logfile=${BUILD_JSON}" \
-            2>&1 | tee "$BUILD_LOG"
-        else
-          # Fallback to console only
-          dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
-            --verbosity normal \
-            2>&1 | tee "$BUILD_LOG"
-        fi
+        dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
+          --verbosity normal 2>&1 | tee "$BUILD_LOG"
         BUILD_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Parse build results
-        parse_build_results "$BUILD_LOG" "$BUILD_JSON"
+        # Parse build results directly from log
+        # Count unique errors (improved pattern matching)
+        ERROR_COUNT=$(grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | wc -l)
+        
+        # Count unique warnings (improved pattern matching)
+        WARNING_COUNT=$(grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | wc -l)
         
         # Determine build status
         if [[ "$BUILD_EXIT_CODE" -ne 0 ]] || [[ "$ERROR_COUNT" -gt 0 ]]; then
           BUILD_SUCCESS=false
         fi
         
-        # Generate summary
+        # Generate GitHub Actions Summary
+        echo "# 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
         if [[ "$BUILD_SUCCESS" == "true" ]]; then
-          generate_summary "success" "$ERROR_COUNT" "$WARNING_COUNT"
+          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+            echo "🟡 **Build Status:** ⚠️ SUCCESS WITH WARNINGS" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "🟢 **Build Status:** ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
+          fi
         else
-          generate_summary "failed" "$ERROR_COUNT" "$WARNING_COUNT"
+          echo "🔴 **Build Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
         fi
         
-        # Create GitHub annotations
-        create_annotations "error" "errors.txt" 10
-        create_annotations "warning" "warnings.txt" 10
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+        echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| 🔴 Errors | $ERROR_COUNT |" >> $GITHUB_STEP_SUMMARY
+        echo "| 🟡 Warnings | $WARNING_COUNT |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Add error details if any (limit to top 10)
+        if [[ "$ERROR_COUNT" -gt 0 ]]; then
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "<summary>🔴 Build Errors ($ERROR_COUNT)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Create GitHub annotations for errors (limit to top 10)
+          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 | while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              # Try to extract file path, line, column, and message
+              if [[ "$line" =~ ^[[:space:]]*([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*error[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
+                local file_path="${BASH_REMATCH[1]}"
+                local line_num="${BASH_REMATCH[2]}"
+                local col_num="${BASH_REMATCH[3]}"
+                local code="${BASH_REMATCH[4]}"
+                local message="${BASH_REMATCH[5]}"
+                
+                # Convert to relative path
+                local rel_path=$(echo "$file_path" | sed 's|.*/||')
+                echo "::error file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
+              else
+                echo "::error::${line}"
+              fi
+            fi
+          done
+        fi
+        
+        # Add warning details if any (limit to top 10)
+        if [[ "$WARNING_COUNT" -gt 0 ]]; then
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "<summary>🟡 Build Warnings ($WARNING_COUNT)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Create GitHub annotations for warnings (limit to top 10)
+          grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u | head -10 | while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              # Try to extract file path, line, column, and message
+              if [[ "$line" =~ ^[[:space:]]*([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*warning[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
+                local file_path="${BASH_REMATCH[1]}"
+                local line_num="${BASH_REMATCH[2]}"
+                local col_num="${BASH_REMATCH[3]}"
+                local code="${BASH_REMATCH[4]}"
+                local message="${BASH_REMATCH[5]}"
+                
+                # Convert to relative path
+                local rel_path=$(echo "$file_path" | sed 's|.*/||')
+                echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
+              else
+                echo "::warning::${line}"
+              fi
+            fi
+          done
+        fi
         
         # Output final status messages
         if [[ "$BUILD_SUCCESS" == "false" ]]; then
@@ -248,7 +200,9 @@ runs:
         echo "BUILD_SUCCESS=$BUILD_SUCCESS" >> $GITHUB_ENV
         echo "BUILD_ERROR_COUNT=$ERROR_COUNT" >> $GITHUB_ENV
         echo "BUILD_WARNING_COUNT=$WARNING_COUNT" >> $GITHUB_ENV
-        echo "BUILD_LOG_PATH=$PWD/$BUILD_LOG" >> $GITHUB_ENV
+        
+        # Clean up temp file
+        rm -f "$BUILD_LOG"
         
         # Exit with error if build failed
         if [[ "$BUILD_SUCCESS" == "false" ]]; then
@@ -265,103 +219,48 @@ runs:
       run: |
         # Initialize test variables
         TEST_SUCCESS=true
-        TEST_LOG="test-output.log"
-        TEST_RESULTS_FILE="test-results.trx"
+        TEST_LOG=$(mktemp)
         PASSED=0
         FAILED=0
         SKIPPED=0
         TOTAL=0
         
-        # Function to parse TRX file for detailed test results
-        parse_test_results() {
-          local trx_file="$1"
-          
-          if [[ -f "$trx_file" ]] && command -v xmllint >/dev/null 2>&1; then
-            # Parse TRX file for detailed results
-            TOTAL=$(xmllint --xpath "count(//UnitTestResult)" "$trx_file" 2>/dev/null || echo "0")
-            PASSED=$(xmllint --xpath "count(//UnitTestResult[@outcome='Passed'])" "$trx_file" 2>/dev/null || echo "0")
-            FAILED=$(xmllint --xpath "count(//UnitTestResult[@outcome='Failed'])" "$trx_file" 2>/dev/null || echo "0")
-            SKIPPED=$(xmllint --xpath "count(//UnitTestResult[@outcome='NotExecuted' or @outcome='Skipped'])" "$trx_file" 2>/dev/null || echo "0")
-            
-            # Extract failed test details
-            if [[ "$FAILED" -gt 0 ]]; then
-              xmllint --xpath "//UnitTestResult[@outcome='Failed']/@testName" "$trx_file" 2>/dev/null | \
-                sed 's/testName="//g' | sed 's/"//g' | sort > failed-tests.txt || touch failed-tests.txt
-            fi
-          else
-            # Fallback to log parsing
-            PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-            FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-            SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-            TOTAL=$((PASSED + FAILED + SKIPPED))
-            
-            # Extract failed test names from log
-            if [[ "$FAILED" -gt 0 ]]; then
-              grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -20 > failed-tests.txt || touch failed-tests.txt
-            fi
-          fi
-        }
-        
-        # Function to generate test summary
-        generate_test_summary() {
-          local test_status="$1"
-          local total="$2"
-          local passed="$3"
-          local failed="$4"
-          local skipped="$5"
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ "$test_status" == "success" ]]; then
-            if [[ "$skipped" -gt 0 ]]; then
-              echo "🟡 **Test Status:** ⚠️ PASSED WITH SKIPPED TESTS" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "🟢 **Test Status:** ✅ ALL PASSED" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "🔴 **Test Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 📊 Total Tests | $total |" >> $GITHUB_STEP_SUMMARY
-          echo "| ✅ Passed | $passed |" >> $GITHUB_STEP_SUMMARY
-          echo "| ❌ Failed | $failed |" >> $GITHUB_STEP_SUMMARY
-          echo "| ⏭️ Skipped | $skipped |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Add failed test details if any
-          if [[ "$failed" -gt 0 ]] && [[ -f "failed-tests.txt" ]]; then
-            echo "<details>" >> $GITHUB_STEP_SUMMARY
-            echo "<summary>❌ Failed Tests ($failed)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            head -20 failed-tests.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-        }
-        
         echo "::group::Test Output"
         
-        # Run tests with structured output
+        # Run tests and capture output
         set +e
         dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} \
           --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} \
-          --logger "trx;LogFileName=${TEST_RESULTS_FILE}" \
-          --logger "console;verbosity=detailed" \
-          2>&1 | tee "$TEST_LOG"
+          --logger "console;verbosity=detailed" 2>&1 | tee "$TEST_LOG"
         TEST_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Parse test results
-        parse_test_results "$TEST_RESULTS_FILE"
+        # Parse test results from console output
+        # Try multiple patterns to catch different dotnet output formats
+        PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        
+        # Alternative parsing for different output formats
+        if [[ "$PASSED" == "0" ]] && [[ "$FAILED" == "0" ]] && [[ "$SKIPPED" == "0" ]]; then
+          # Try alternative patterns
+          PASSED=$(grep -oP 'Passed!\s*-\s*Failed:\s*0,\s*Passed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
+          FAILED=$(grep -oP 'Failed!\s*-\s*Failed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
+          
+          # Try yet another pattern
+          if [[ "$PASSED" == "0" ]] && [[ "$FAILED" == "0" ]]; then
+            TOTAL_LINE=$(grep -E "Total tests:|Tests run:" "$TEST_LOG" | tail -1 || echo "")
+            if [[ -n "$TOTAL_LINE" ]]; then
+              PASSED=$(echo "$TOTAL_LINE" | grep -oP 'Passed:\s*\K[0-9]+' || echo "0")
+              FAILED=$(echo "$TOTAL_LINE" | grep -oP 'Failed:\s*\K[0-9]+' || echo "0")
+              SKIPPED=$(echo "$TOTAL_LINE" | grep -oP 'Skipped:\s*\K[0-9]+' || echo "0")
+            fi
+          fi
+        fi
+        
+        TOTAL=$((PASSED + FAILED + SKIPPED))
         
         # Determine test status
         if [[ "$TEST_EXIT_CODE" -ne 0 ]] || [[ "$FAILED" -gt 0 ]]; then
@@ -369,15 +268,47 @@ runs:
         fi
         
         # Generate test summary
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "# 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
         if [[ "$TEST_SUCCESS" == "true" ]]; then
-          generate_test_summary "success" "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED"
+          if [[ "$SKIPPED" -gt 0 ]]; then
+            echo "🟡 **Test Status:** ⚠️ PASSED WITH SKIPPED TESTS" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "🟢 **Test Status:** ✅ ALL PASSED" >> $GITHUB_STEP_SUMMARY
+          fi
         else
-          generate_test_summary "failed" "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED"
+          echo "🔴 **Test Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
         fi
         
-        # Create GitHub annotations for failed tests
-        if [[ "$FAILED" -gt 0 ]] && [[ -f "failed-tests.txt" ]]; then
-          head -10 failed-tests.txt | while IFS= read -r line; do
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+        echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| 📊 Total Tests | $TOTAL |" >> $GITHUB_STEP_SUMMARY
+        echo "| ✅ Passed | $PASSED |" >> $GITHUB_STEP_SUMMARY
+        echo "| ❌ Failed | $FAILED |" >> $GITHUB_STEP_SUMMARY
+        echo "| ⏭️ Skipped | $SKIPPED |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Add failed test details if any
+        if [[ "$FAILED" -gt 0 ]]; then
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "<summary>❌ Failed Tests ($FAILED)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          # Extract failed test names from output (multiple patterns)
+          grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 >> $GITHUB_STEP_SUMMARY || \
+          grep -E "^\s*X\s+" "$TEST_LOG" | head -10 >> $GITHUB_STEP_SUMMARY || \
+          echo "Failed test details not available in this format" >> $GITHUB_STEP_SUMMARY
+          
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Create GitHub annotations for failed tests
+          grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 | while IFS= read -r line; do
             if [[ -n "$line" ]]; then
               echo "::error::❌ Failed Test: $line"
             fi
@@ -390,8 +321,10 @@ runs:
         else
           if [[ "$SKIPPED" -gt 0 ]]; then
             echo "::warning::⚠️ All tests passed but $SKIPPED test(s) were skipped"
-          else
+          elif [[ "$TOTAL" -gt 0 ]]; then
             echo "::notice::✅ All $PASSED test(s) passed"
+          else
+            echo "::warning::⚠️ No tests found to execute"
           fi
         fi
         
@@ -401,170 +334,35 @@ runs:
         echo "TEST_PASSED=$PASSED" >> $GITHUB_ENV
         echo "TEST_FAILED=$FAILED" >> $GITHUB_ENV
         echo "TEST_SKIPPED=$SKIPPED" >> $GITHUB_ENV
-        echo "TEST_LOG_PATH=$PWD/$TEST_LOG" >> $GITHUB_ENV
-        echo "TEST_RESULTS_PATH=$PWD/$TEST_RESULTS_FILE" >> $GITHUB_ENV
+        
+        # Clean up temp file
+        rm -f "$TEST_LOG"
         
         # Exit with error if tests failed
         if [[ "$TEST_SUCCESS" == "false" ]]; then
           exit 1
         fi
 
-    - name: Create PR Comment
-      if: always() && github.event_name == 'pull_request' && inputs.create-pr-comment == 'true'
-      uses: actions/github-script@v7
-      env:
-        BUILD_SUCCESS: ${{ env.BUILD_SUCCESS }}
-        BUILD_ERROR_COUNT: ${{ env.BUILD_ERROR_COUNT }}
-        BUILD_WARNING_COUNT: ${{ env.BUILD_WARNING_COUNT }}
-        TEST_SUCCESS: ${{ env.TEST_SUCCESS }}
-        TEST_TOTAL: ${{ env.TEST_TOTAL }}
-        TEST_PASSED: ${{ env.TEST_PASSED }}
-        TEST_FAILED: ${{ env.TEST_FAILED }}
-        TEST_SKIPPED: ${{ env.TEST_SKIPPED }}
-      with:
-        script: |
-          const fs = require('fs');
-          
-          // Read error and warning files if they exist
-          let errorDetails = '';
-          let warningDetails = '';
-          let failedTestDetails = '';
-          
-          try {
-            if (fs.existsSync('errors.txt')) {
-              const errors = fs.readFileSync('errors.txt', 'utf8').trim();
-              if (errors) {
-                const errorLines = errors.split('\n').slice(0, 5);
-                errorDetails = '\n\n**Top Errors:**\n```\n' + errorLines.join('\n') + '\n```';
-              }
-            }
-          } catch (e) {}
-          
-          try {
-            if (fs.existsSync('warnings.txt')) {
-              const warnings = fs.readFileSync('warnings.txt', 'utf8').trim();
-              if (warnings) {
-                const warningLines = warnings.split('\n').slice(0, 5);
-                warningDetails = '\n\n**Top Warnings:**\n```\n' + warningLines.join('\n') + '\n```';
-              }
-            }
-          } catch (e) {}
-          
-          try {
-            if (fs.existsSync('failed-tests.txt')) {
-              const failedTests = fs.readFileSync('failed-tests.txt', 'utf8').trim();
-              if (failedTests) {
-                const testLines = failedTests.split('\n').slice(0, 5);
-                failedTestDetails = '\n\n**Failed Tests:**\n```\n' + testLines.join('\n') + '\n```';
-              }
-            }
-          } catch (e) {}
-          
-          // Determine overall status
-          const buildSuccess = process.env.BUILD_SUCCESS === 'true';
-          const testSuccess = process.env.TEST_SUCCESS === 'true';
-          const overallSuccess = buildSuccess && testSuccess;
-          
-          // Build status emoji and text
-          let buildStatus = '';
-          const errorCount = parseInt(process.env.BUILD_ERROR_COUNT || '0');
-          const warningCount = parseInt(process.env.BUILD_WARNING_COUNT || '0');
-          
-          if (!buildSuccess) {
-            buildStatus = '🔴 ❌ **FAILED**';
-          } else if (warningCount > 0) {
-            buildStatus = '🟡 ⚠️ **SUCCESS WITH WARNINGS**';
-          } else {
-            buildStatus = '🟢 ✅ **SUCCESS**';
-          }
-          
-          // Test status emoji and text
-          let testStatus = '';
-          const testTotal = parseInt(process.env.TEST_TOTAL || '0');
-          const testPassed = parseInt(process.env.TEST_PASSED || '0');
-          const testFailed = parseInt(process.env.TEST_FAILED || '0');
-          const testSkipped = parseInt(process.env.TEST_SKIPPED || '0');
-          
-          if (!testSuccess) {
-            testStatus = '🔴 ❌ **FAILED**';
-          } else if (testSkipped > 0) {
-            testStatus = '🟡 ⚠️ **PASSED WITH SKIPPED**';
-          } else {
-            testStatus = '🟢 ✅ **ALL PASSED**';
-          }
-          
-          // Create comment body
-          const commentBody = `## 🔨 .NET CI Results
-          
-          ### Build Results
-          **Status:** ${buildStatus}
-          - 🔴 Errors: ${errorCount}
-          - 🟡 Warnings: ${warningCount}${errorDetails}${warningDetails}
-          
-          ### Test Results  
-          **Status:** ${testStatus}
-          - 📊 Total: ${testTotal}
-          - ✅ Passed: ${testPassed}
-          - ❌ Failed: ${testFailed}
-          - ⏭️ Skipped: ${testSkipped}${failedTestDetails}
-          
-          ---
-          
-          ${overallSuccess ? '🎉 **Overall Status: SUCCESS**' : '💥 **Overall Status: FAILED**'}
-          
-          [View detailed results in Actions](${context.payload.pull_request.html_url.replace('/pull/', '/actions/runs/')})`;
-          
-          // Find existing comment to update or create new one
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          
-          const botComment = comments.find(comment => 
-            comment.user.type === 'Bot' && 
-            comment.body.includes('🔨 .NET CI Results')
-          );
-          
-          if (botComment) {
-            // Update existing comment
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: commentBody
-            });
-          } else {
-            // Create new comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: commentBody
-            });
-          }
-
-    - name: Upload Build and Test Logs
-      uses: actions/upload-artifact@v4
+    - name: Final Summary
       if: always()
-      with:
-        name: build-and-test-logs
-        path: |
-          build-output.log
-          test-output.log
-          test-results.trx
-          build-results.json
-          errors.txt
-          warnings.txt
-          failed-tests.txt
-        retention-days: 30
-        if-no-files-found: ignore
-
-    - name: Publish Test Results
-      uses: dorny/test-reporter@v1
-      if: always()
-      with:
-        name: .NET Test Results
-        path: test-results.trx
-        reporter: dotnet-trx
-        fail-on-error: false
+      shell: bash
+      run: |
+        # Generate final summary section
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "---" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Determine overall status
+        BUILD_SUCCESS="${BUILD_SUCCESS:-false}"
+        TEST_SUCCESS="${TEST_SUCCESS:-false}"
+        
+        if [[ "$BUILD_SUCCESS" == "true" ]] && [[ "$TEST_SUCCESS" == "true" ]]; then
+          echo "🎉 **Overall Status: SUCCESS** ✅" >> $GITHUB_STEP_SUMMARY
+          echo "::notice::🎉 CI pipeline completed successfully!"
+        else
+          echo "💥 **Overall Status: FAILED** ❌" >> $GITHUB_STEP_SUMMARY
+          echo "::error::💥 CI pipeline failed - check the details above"
+        fi
+        
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "_Generated by .NET Continuous Integration Action_" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,10 @@ inputs:
     description: 'Extra arguments to pass to dotnet test'
     required: false
     default: ''
+  create-pr-comment:
+    description: 'Create a PR comment with build/test results'
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -60,170 +64,198 @@ runs:
         SOLUTION_PATH: ${{ inputs.solution-path }}
       run: dotnet restore ${{ env.SOLUTION_PATH }}
 
-    - name: Build
+    - name: Build and Analyze
       shell: bash
       env:
         BUILD_CONFIGURATION: ${{ inputs.build-configuration }}
         SOLUTION_PATH: ${{ inputs.solution-path }}
         ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
       run: |
+        # Initialize variables
+        BUILD_SUCCESS=true
+        ERROR_COUNT=0
+        WARNING_COUNT=0
+        BUILD_LOG="build-output.log"
+        BUILD_JSON="build-results.json"
+        
+        # Function to parse build results from structured output
+        parse_build_results() {
+          local log_file="$1"
+          local json_file="$2"
+          
+          # Try to parse JSON output first (more reliable)
+          if [[ -f "$json_file" ]] && command -v jq >/dev/null 2>&1; then
+            # Parse JSON structured output
+            ERROR_COUNT=$(jq -r '[.[] | select(.level == "error")] | length' "$json_file" 2>/dev/null || echo "0")
+            WARNING_COUNT=$(jq -r '[.[] | select(.level == "warning")] | length' "$json_file" 2>/dev/null || echo "0")
+            
+            # Extract unique errors
+            if [[ "$ERROR_COUNT" -gt 0 ]]; then
+              jq -r '.[] | select(.level == "error") | "\(.file // "")(\(.line // ""),\(.column // "")): error \(.code // ""): \(.message // "")"' "$json_file" 2>/dev/null | sort -u > errors.txt
+            fi
+            
+            # Extract unique warnings  
+            if [[ "$WARNING_COUNT" -gt 0 ]]; then
+              jq -r '.[] | select(.level == "warning") | "\(.file // "")(\(.line // ""),\(.column // "")): warning \(.code // ""): \(.message // "")"' "$json_file" 2>/dev/null | sort -u > warnings.txt
+            fi
+          else
+            # Fallback to improved text parsing
+            # Extract errors with improved pattern matching
+            grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:' "$log_file" | sort -u > errors.txt 2>/dev/null || touch errors.txt
+            ERROR_COUNT=$(wc -l < errors.txt)
+            
+            # Extract warnings with improved pattern matching
+            grep -E '^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:' "$log_file" | sort -u > warnings.txt 2>/dev/null || touch warnings.txt
+            WARNING_COUNT=$(wc -l < warnings.txt)
+          fi
+        }
+        
+        # Function to create GitHub annotations
+        create_annotations() {
+          local type="$1"
+          local file="$2"
+          local limit="${3:-10}"
+          
+          if [[ -f "$file" ]] && [[ -s "$file" ]]; then
+            head -n "$limit" "$file" | while IFS= read -r line; do
+              if [[ -n "$line" ]]; then
+                # Extract file path, line, column, and message
+                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):[[:space:]]*${type}[[:space:]]+([^:]+):[[:space:]]*(.*)$ ]]; then
+                  local file_path="${BASH_REMATCH[1]}"
+                  local line_num="${BASH_REMATCH[2]}"
+                  local col_num="${BASH_REMATCH[3]}"
+                  local code="${BASH_REMATCH[4]}"
+                  local message="${BASH_REMATCH[5]}"
+                  
+                  # Convert to relative path
+                  local rel_path=$(echo "$file_path" | sed 's|.*/||')
+                  echo "::${type} file=${rel_path},line=${line_num},col=${col_num}::${code}: ${message}"
+                else
+                  echo "::${type}::${line}"
+                fi
+              fi
+            done
+          fi
+        }
+        
+        # Function to generate summary content
+        generate_summary() {
+          local build_status="$1"
+          local error_count="$2"
+          local warning_count="$3"
+          
+          echo "# 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "$build_status" == "success" ]]; then
+            if [[ "$warning_count" -gt 0 ]]; then
+              echo "🟡 **Build Status:** ⚠️ SUCCESS WITH WARNINGS" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "🟢 **Build Status:** ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "🔴 **Build Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔴 Errors | $error_count |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🟡 Warnings | $warning_count |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Add error details if any
+          if [[ "$error_count" -gt 0 ]] && [[ -f "errors.txt" ]]; then
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>🔴 Build Errors ($error_count)</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            head -20 errors.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Add warning details if any
+          if [[ "$warning_count" -gt 0 ]] && [[ -f "warnings.txt" ]]; then
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>🟡 Build Warnings ($warning_count)</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            head -20 warnings.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+        }
+        
         echo "::group::Build Output"
         
-        # Create build log file
-        BUILD_LOG="build-output.log"
-        
-        # Run build and capture both stdout and stderr, preserve exit code
+        # Run build with structured logging
         set +e
-        dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} 2>&1 | tee "$BUILD_LOG"
+        if command -v jq >/dev/null 2>&1; then
+          # Use JSON logger if jq is available
+          dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
+            --logger "console;verbosity=minimal" \
+            --logger "json;logfile=${BUILD_JSON}" \
+            2>&1 | tee "$BUILD_LOG"
+        else
+          # Fallback to console only
+          dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} \
+            --verbosity normal \
+            2>&1 | tee "$BUILD_LOG"
+        fi
         BUILD_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Initialize summary
-        echo "## 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        # Parse build results
+        parse_build_results "$BUILD_LOG" "$BUILD_JSON"
         
-        # Parse build output for errors and warnings with improved patterns
-        # Extract unique errors and warnings first, then count them
-        UNIQUE_ERRORS=$(grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u || true)
-        UNIQUE_WARNINGS=$(grep -E '(warning\s[A-Z]{2}[0-9]{4}:|warning\s[A-Z]+[0-9]+:|\bwarning\b.*:)' "$BUILD_LOG" | sort -u || true)
-        
-        # Count unique errors and warnings
-        if [[ -n "$UNIQUE_ERRORS" ]]; then
-          ERROR_COUNT=$(echo "$UNIQUE_ERRORS" | wc -l)
-        else
-          ERROR_COUNT=0
-        fi
-        
-        if [[ -n "$UNIQUE_WARNINGS" ]]; then
-          WARNING_COUNT=$(echo "$UNIQUE_WARNINGS" | wc -l)
-        else
-          WARNING_COUNT=0
-        fi
-        
-        # Debug output to help troubleshoot detection
-        echo "::debug::Found $ERROR_COUNT unique errors and $WARNING_COUNT unique warnings in build log"
-        echo "::debug::Checking for any lines containing 'warning' (case insensitive):"
-        grep -i 'warning' "$BUILD_LOG" | head -5 || echo "::debug::No lines containing 'warning' found"
-        
-        if [[ "$WARNING_COUNT" -gt 0 ]]; then
-          echo "::debug::Sample warnings found:"
-          echo "$UNIQUE_WARNINGS" | head -3 | while read -r line; do
-            echo "::debug::  $line"
-          done
-        fi
-        
+        # Determine build status
         if [[ "$BUILD_EXIT_CODE" -ne 0 ]] || [[ "$ERROR_COUNT" -gt 0 ]]; then
-          echo "❌ **Build Status:** FAILED" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Errors:** $ERROR_COUNT" >> $GITHUB_STEP_SUMMARY
-          echo "- **Warnings:** $WARNING_COUNT" >> $GITHUB_STEP_SUMMARY
-          echo "- **Exit Code:** $BUILD_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Show errors in summary
-          if [[ "$ERROR_COUNT" -gt 0 ]]; then
-            echo "### ❌ Build Errors" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$UNIQUE_ERRORS" | head -10 >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Output as GitHub annotations with file/line info when possible
-            echo "$UNIQUE_ERRORS" | head -10 | while read -r line; do
-              if [[ -n "$line" ]]; then
-                # Try to extract file path and line number for better annotations
-                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*error.*:(.*)$ ]]; then
-                  file_path="${BASH_REMATCH[1]}"
-                  line_num="${BASH_REMATCH[2]}"
-                  col_num="${BASH_REMATCH[3]}"
-                  error_msg="${BASH_REMATCH[4]}"
-                  # Convert absolute path to relative if possible
-                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
-                  echo "::error file=${rel_path},line=${line_num},col=${col_num}::${error_msg}"
-                else
-                  echo "::error::$line"
-                fi
-              fi
-            done
-          fi
-          
-          # Show warnings in summary if any (deduplicated)
-          if [[ "$WARNING_COUNT" -gt 0 ]]; then
-            echo "### ⚠️ Build Warnings" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$UNIQUE_WARNINGS" | head -10 >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Output as GitHub annotations with file/line info when possible
-            echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
-              if [[ -n "$line" ]]; then
-                # Try to extract file path and line number for better annotations
-                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*warning.*:(.*)$ ]]; then
-                  file_path="${BASH_REMATCH[1]}"
-                  line_num="${BASH_REMATCH[2]}"
-                  col_num="${BASH_REMATCH[3]}"
-                  warning_msg="${BASH_REMATCH[4]}"
-                  # Convert absolute path to relative if possible
-                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
-                  echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${warning_msg}"
-                else
-                  echo "::warning::$line"
-                fi
-              fi
-            done
-          fi
-          
-          # Single summary error message
-          if [[ "$WARNING_COUNT" -gt 0 ]]; then
-            echo "::error::Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
-          else
-            echo "::error::Build failed with $ERROR_COUNT error(s)"
-          fi
-          exit 1
+          BUILD_SUCCESS=false
+        fi
+        
+        # Generate summary
+        if [[ "$BUILD_SUCCESS" == "true" ]]; then
+          generate_summary "success" "$ERROR_COUNT" "$WARNING_COUNT"
         else
-          echo "✅ **Build Status:** SUCCESS" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Errors:** $ERROR_COUNT" >> $GITHUB_STEP_SUMMARY
-          echo "- **Warnings:** $WARNING_COUNT" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
+          generate_summary "failed" "$ERROR_COUNT" "$WARNING_COUNT"
+        fi
+        
+        # Create GitHub annotations
+        create_annotations "error" "errors.txt" 10
+        create_annotations "warning" "warnings.txt" 10
+        
+        # Output final status messages
+        if [[ "$BUILD_SUCCESS" == "false" ]]; then
           if [[ "$WARNING_COUNT" -gt 0 ]]; then
-            echo "### ⚠️ Build Warnings" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$UNIQUE_WARNINGS" | head -10 >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Output as GitHub annotations with file/line info when possible
-            echo "$UNIQUE_WARNINGS" | head -10 | while read -r line; do
-              if [[ -n "$line" ]]; then
-                # Try to extract file path and line number for better annotations
-                if [[ "$line" =~ ^([^(]+)\(([0-9]+),([0-9]+)\):.*warning.*:(.*)$ ]]; then
-                  file_path="${BASH_REMATCH[1]}"
-                  line_num="${BASH_REMATCH[2]}"
-                  col_num="${BASH_REMATCH[3]}"
-                  warning_msg="${BASH_REMATCH[4]}"
-                  # Convert absolute path to relative if possible
-                  rel_path=$(echo "$file_path" | sed 's|.*/src/|src/|')
-                  echo "::warning file=${rel_path},line=${line_num},col=${col_num}::${warning_msg}"
-                else
-                  echo "::warning::$line"
-                fi
-              fi
-            done
-            echo "::warning::Build succeeded with $WARNING_COUNT warning(s)"
+            echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
           else
-            echo "::notice::✅ Build succeeded with no warnings or errors"
+            echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
+          fi
+        else
+          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+            echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
+          else
+            echo "::notice::✅ Build succeeded with no errors or warnings"
           fi
         fi
         
-        # Set absolute path for build log artifact
+        # Export variables for later steps
+        echo "BUILD_SUCCESS=$BUILD_SUCCESS" >> $GITHUB_ENV
+        echo "BUILD_ERROR_COUNT=$ERROR_COUNT" >> $GITHUB_ENV
+        echo "BUILD_WARNING_COUNT=$WARNING_COUNT" >> $GITHUB_ENV
         echo "BUILD_LOG_PATH=$PWD/$BUILD_LOG" >> $GITHUB_ENV
+        
+        # Exit with error if build failed
+        if [[ "$BUILD_SUCCESS" == "false" ]]; then
+          exit 1
+        fi
 
-    - name: Run tests
+    - name: Run Tests and Analyze
       shell: bash
       env:
         BUILD_CONFIGURATION: ${{ inputs.build-configuration }}
@@ -231,96 +263,286 @@ runs:
         TEST_VERBOSITY: ${{ inputs.test-verbosity }}
         ADDITIONAL_TEST_ARGUMENTS: ${{ inputs.additional-test-arguments }}
       run: |
+        # Initialize test variables
+        TEST_SUCCESS=true
+        TEST_LOG="test-output.log"
+        TEST_RESULTS_FILE="test-results.trx"
+        PASSED=0
+        FAILED=0
+        SKIPPED=0
+        TOTAL=0
+        
+        # Function to parse TRX file for detailed test results
+        parse_test_results() {
+          local trx_file="$1"
+          
+          if [[ -f "$trx_file" ]] && command -v xmllint >/dev/null 2>&1; then
+            # Parse TRX file for detailed results
+            TOTAL=$(xmllint --xpath "count(//UnitTestResult)" "$trx_file" 2>/dev/null || echo "0")
+            PASSED=$(xmllint --xpath "count(//UnitTestResult[@outcome='Passed'])" "$trx_file" 2>/dev/null || echo "0")
+            FAILED=$(xmllint --xpath "count(//UnitTestResult[@outcome='Failed'])" "$trx_file" 2>/dev/null || echo "0")
+            SKIPPED=$(xmllint --xpath "count(//UnitTestResult[@outcome='NotExecuted' or @outcome='Skipped'])" "$trx_file" 2>/dev/null || echo "0")
+            
+            # Extract failed test details
+            if [[ "$FAILED" -gt 0 ]]; then
+              xmllint --xpath "//UnitTestResult[@outcome='Failed']/@testName" "$trx_file" 2>/dev/null | \
+                sed 's/testName="//g' | sed 's/"//g' | sort > failed-tests.txt || touch failed-tests.txt
+            fi
+          else
+            # Fallback to log parsing
+            PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+            FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+            SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+            TOTAL=$((PASSED + FAILED + SKIPPED))
+            
+            # Extract failed test names from log
+            if [[ "$FAILED" -gt 0 ]]; then
+              grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -20 > failed-tests.txt || touch failed-tests.txt
+            fi
+          fi
+        }
+        
+        # Function to generate test summary
+        generate_test_summary() {
+          local test_status="$1"
+          local total="$2"
+          local passed="$3"
+          local failed="$4"
+          local skipped="$5"
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "$test_status" == "success" ]]; then
+            if [[ "$skipped" -gt 0 ]]; then
+              echo "🟡 **Test Status:** ⚠️ PASSED WITH SKIPPED TESTS" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "🟢 **Test Status:** ✅ ALL PASSED" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "🔴 **Test Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| 📊 Total Tests | $total |" >> $GITHUB_STEP_SUMMARY
+          echo "| ✅ Passed | $passed |" >> $GITHUB_STEP_SUMMARY
+          echo "| ❌ Failed | $failed |" >> $GITHUB_STEP_SUMMARY
+          echo "| ⏭️ Skipped | $skipped |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Add failed test details if any
+          if [[ "$failed" -gt 0 ]] && [[ -f "failed-tests.txt" ]]; then
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>❌ Failed Tests ($failed)</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            head -20 failed-tests.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+        }
+        
         echo "::group::Test Output"
         
-        # Create test log file
-        TEST_LOG="test-output.log"
-        
-        # Run tests and capture both stdout and stderr, preserve exit code
+        # Run tests with structured output
         set +e
-        dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed" 2>&1 | tee "$TEST_LOG"
+        dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} \
+          --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} \
+          --logger "trx;LogFileName=${TEST_RESULTS_FILE}" \
+          --logger "console;verbosity=detailed" \
+          2>&1 | tee "$TEST_LOG"
         TEST_EXIT_CODE=$?
         set -e
         
         echo "::endgroup::"
         
-        # Add test results to summary
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        # Parse test results
+        parse_test_results "$TEST_RESULTS_FILE"
         
-        # Parse test output for results
-        PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-        FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-        SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
-        TOTAL=$((PASSED + FAILED + SKIPPED))
-        
-        # Handle case where no tests were found
-        if [[ "$TOTAL" -eq 0 ]]; then
-          # Try alternative parsing for different dotnet output formats
-          PASSED=$(grep -oP 'Passed!\s*-\s*Failed:\s*0,\s*Passed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
-          FAILED=$(grep -oP 'Failed!\s*-\s*Failed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
-          TOTAL=$((PASSED + FAILED + SKIPPED))
-        fi
-        
+        # Determine test status
         if [[ "$TEST_EXIT_CODE" -ne 0 ]] || [[ "$FAILED" -gt 0 ]]; then
-          echo "❌ **Test Status:** FAILED" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Total Tests:** $TOTAL" >> $GITHUB_STEP_SUMMARY
-          echo "- **Passed:** $PASSED" >> $GITHUB_STEP_SUMMARY
-          echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY
-          echo "- **Skipped:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
-          echo "- **Exit Code:** $TEST_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Show failed tests in summary
-          if [[ "$FAILED" -gt 0 ]]; then
-            echo "### ❌ Failed Tests" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            
-            # Extract failed test names from output
-            grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 >> $GITHUB_STEP_SUMMARY || echo "Failed test details not available in this format" >> $GITHUB_STEP_SUMMARY
-            
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Also output as GitHub annotations
-            grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 | while read -r line; do
-              echo "::error::❌ Failed Test: $line"
-            done
-          fi
-          
-          echo "::error::❌ $FAILED test(s) failed out of $TOTAL total tests"
-          exit 1
+          TEST_SUCCESS=false
+        fi
+        
+        # Generate test summary
+        if [[ "$TEST_SUCCESS" == "true" ]]; then
+          generate_test_summary "success" "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED"
         else
-          echo "✅ **Test Status:** SUCCESS" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Total Tests:** $TOTAL" >> $GITHUB_STEP_SUMMARY
-          echo "- **Passed:** $PASSED" >> $GITHUB_STEP_SUMMARY
-          echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY
-          echo "- **Skipped:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
+          generate_test_summary "failed" "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED"
+        fi
+        
+        # Create GitHub annotations for failed tests
+        if [[ "$FAILED" -gt 0 ]] && [[ -f "failed-tests.txt" ]]; then
+          head -10 failed-tests.txt | while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              echo "::error::❌ Failed Test: $line"
+            fi
+          done
+        fi
+        
+        # Output final test status messages
+        if [[ "$TEST_SUCCESS" == "false" ]]; then
+          echo "::error::❌ $FAILED test(s) failed out of $TOTAL total tests"
+        else
           if [[ "$SKIPPED" -gt 0 ]]; then
-            echo "### ⚠️ Skipped Tests" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            grep -E "(SKIP|Skipped)" "$TEST_LOG" | grep -v "Skipped:" | head -10 >> $GITHUB_STEP_SUMMARY || echo "Skipped test details not available in this format" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            echo "::warning::⚠️ $SKIPPED test(s) skipped"
-          fi
-          
-          if [[ "$TOTAL" -gt 0 ]]; then
-            echo "::notice::✅ All $PASSED test(s) passed out of $TOTAL total tests"
+            echo "::warning::⚠️ All tests passed but $SKIPPED test(s) were skipped"
           else
-            echo "::warning::⚠️ No tests found to execute"
+            echo "::notice::✅ All $PASSED test(s) passed"
           fi
         fi
         
-        # Set absolute paths for test artifacts
+        # Export variables for later steps
+        echo "TEST_SUCCESS=$TEST_SUCCESS" >> $GITHUB_ENV
+        echo "TEST_TOTAL=$TOTAL" >> $GITHUB_ENV
+        echo "TEST_PASSED=$PASSED" >> $GITHUB_ENV
+        echo "TEST_FAILED=$FAILED" >> $GITHUB_ENV
+        echo "TEST_SKIPPED=$SKIPPED" >> $GITHUB_ENV
         echo "TEST_LOG_PATH=$PWD/$TEST_LOG" >> $GITHUB_ENV
-        echo "TEST_RESULTS_PATH=$PWD/test-results.trx" >> $GITHUB_ENV
+        echo "TEST_RESULTS_PATH=$PWD/$TEST_RESULTS_FILE" >> $GITHUB_ENV
+        
+        # Exit with error if tests failed
+        if [[ "$TEST_SUCCESS" == "false" ]]; then
+          exit 1
+        fi
+
+    - name: Create PR Comment
+      if: always() && github.event_name == 'pull_request' && inputs.create-pr-comment == 'true'
+      uses: actions/github-script@v7
+      env:
+        BUILD_SUCCESS: ${{ env.BUILD_SUCCESS }}
+        BUILD_ERROR_COUNT: ${{ env.BUILD_ERROR_COUNT }}
+        BUILD_WARNING_COUNT: ${{ env.BUILD_WARNING_COUNT }}
+        TEST_SUCCESS: ${{ env.TEST_SUCCESS }}
+        TEST_TOTAL: ${{ env.TEST_TOTAL }}
+        TEST_PASSED: ${{ env.TEST_PASSED }}
+        TEST_FAILED: ${{ env.TEST_FAILED }}
+        TEST_SKIPPED: ${{ env.TEST_SKIPPED }}
+      with:
+        script: |
+          const fs = require('fs');
+          
+          // Read error and warning files if they exist
+          let errorDetails = '';
+          let warningDetails = '';
+          let failedTestDetails = '';
+          
+          try {
+            if (fs.existsSync('errors.txt')) {
+              const errors = fs.readFileSync('errors.txt', 'utf8').trim();
+              if (errors) {
+                const errorLines = errors.split('\n').slice(0, 5);
+                errorDetails = '\n\n**Top Errors:**\n```\n' + errorLines.join('\n') + '\n```';
+              }
+            }
+          } catch (e) {}
+          
+          try {
+            if (fs.existsSync('warnings.txt')) {
+              const warnings = fs.readFileSync('warnings.txt', 'utf8').trim();
+              if (warnings) {
+                const warningLines = warnings.split('\n').slice(0, 5);
+                warningDetails = '\n\n**Top Warnings:**\n```\n' + warningLines.join('\n') + '\n```';
+              }
+            }
+          } catch (e) {}
+          
+          try {
+            if (fs.existsSync('failed-tests.txt')) {
+              const failedTests = fs.readFileSync('failed-tests.txt', 'utf8').trim();
+              if (failedTests) {
+                const testLines = failedTests.split('\n').slice(0, 5);
+                failedTestDetails = '\n\n**Failed Tests:**\n```\n' + testLines.join('\n') + '\n```';
+              }
+            }
+          } catch (e) {}
+          
+          // Determine overall status
+          const buildSuccess = process.env.BUILD_SUCCESS === 'true';
+          const testSuccess = process.env.TEST_SUCCESS === 'true';
+          const overallSuccess = buildSuccess && testSuccess;
+          
+          // Build status emoji and text
+          let buildStatus = '';
+          const errorCount = parseInt(process.env.BUILD_ERROR_COUNT || '0');
+          const warningCount = parseInt(process.env.BUILD_WARNING_COUNT || '0');
+          
+          if (!buildSuccess) {
+            buildStatus = '🔴 ❌ **FAILED**';
+          } else if (warningCount > 0) {
+            buildStatus = '🟡 ⚠️ **SUCCESS WITH WARNINGS**';
+          } else {
+            buildStatus = '🟢 ✅ **SUCCESS**';
+          }
+          
+          // Test status emoji and text
+          let testStatus = '';
+          const testTotal = parseInt(process.env.TEST_TOTAL || '0');
+          const testPassed = parseInt(process.env.TEST_PASSED || '0');
+          const testFailed = parseInt(process.env.TEST_FAILED || '0');
+          const testSkipped = parseInt(process.env.TEST_SKIPPED || '0');
+          
+          if (!testSuccess) {
+            testStatus = '🔴 ❌ **FAILED**';
+          } else if (testSkipped > 0) {
+            testStatus = '🟡 ⚠️ **PASSED WITH SKIPPED**';
+          } else {
+            testStatus = '🟢 ✅ **ALL PASSED**';
+          }
+          
+          // Create comment body
+          const commentBody = `## 🔨 .NET CI Results
+          
+          ### Build Results
+          **Status:** ${buildStatus}
+          - 🔴 Errors: ${errorCount}
+          - 🟡 Warnings: ${warningCount}${errorDetails}${warningDetails}
+          
+          ### Test Results  
+          **Status:** ${testStatus}
+          - 📊 Total: ${testTotal}
+          - ✅ Passed: ${testPassed}
+          - ❌ Failed: ${testFailed}
+          - ⏭️ Skipped: ${testSkipped}${failedTestDetails}
+          
+          ---
+          
+          ${overallSuccess ? '🎉 **Overall Status: SUCCESS**' : '💥 **Overall Status: FAILED**'}
+          
+          [View detailed results in Actions](${context.payload.pull_request.html_url.replace('/pull/', '/actions/runs/')})`;
+          
+          // Find existing comment to update or create new one
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          
+          const botComment = comments.find(comment => 
+            comment.user.type === 'Bot' && 
+            comment.body.includes('🔨 .NET CI Results')
+          );
+          
+          if (botComment) {
+            // Update existing comment
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: commentBody
+            });
+          } else {
+            // Create new comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody
+            });
+          }
 
     - name: Upload Build and Test Logs
       uses: actions/upload-artifact@v4
@@ -331,6 +553,10 @@ runs:
           build-output.log
           test-output.log
           test-results.trx
+          build-results.json
+          errors.txt
+          warnings.txt
+          failed-tests.txt
         retention-days: 30
         if-no-files-found: ignore
 

--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,6 @@ runs:
         SOLUTION_PATH: ${{ inputs.solution-path }}
         ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
       run: |
-        # Capture build output to temp file
         BUILD_OUTPUT=$(mktemp)
         
         echo "::group::Build Output"
@@ -81,18 +80,14 @@ runs:
         
         echo "::endgroup::"
         
-        # Process errors using associative array for deduplication
-        # Use specific pattern to match MSBuild error format: file(line,col): error CODE: message
-        # Exclude compiler command lines and GitHub Actions annotations
+        # Dedupe errors and warnings using associative array
+        # error format: file(line,col): error CODE: message        
         declare -A errors_map
         while IFS=':' read -r full_line rest; do
           if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
-            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
             if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
               key="${BASH_REMATCH[1]}"
             else
-              # Fallback: clean up the full line and use as key
               key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
             fi
             rest=$(echo "$rest" | xargs)
@@ -105,42 +100,13 @@ runs:
         
         ERROR_COUNT=${#errors_map[@]}
         
-        # Debug: Show sample of build output for troubleshooting
-        echo "::group::Debug - Build Output Sample (first 50 lines)"
-        head -50 "$BUILD_OUTPUT" || true
-        echo "::endgroup::"
-        
-        echo "::group::Debug - Lines containing 'warning'"
-        grep -i "warning" "$BUILD_OUTPUT" | head -20 || echo "No lines containing 'warning' found"
-        echo "::endgroup::"
-        
-        echo "::group::Debug - Raw grep patterns test"
-        echo "Testing Pattern 1 (strict MSBuild):"
-        grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 1"
-        echo ""
-        echo "Testing Pattern 2 (broader):"
-        grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 2"
-        echo ""
-        echo "Testing Pattern 3 (broadest):"
-        grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 3"
-        echo ""
-        echo "File size and line count:"
-        wc -l "$BUILD_OUTPUT" || echo "Could not count lines"
-        echo "::endgroup::"
-        
-        # Process warnings using associative array for deduplication
-        # Use multiple patterns to catch different warning formats
+        # warning format: file(line, col): warning CODE: message
         declare -A warnings_map
-        
-        # Pattern 1: Standard MSBuild format: file(line,col): warning CODE: message
         while IFS=':' read -r full_line rest; do
           if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
-            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
             if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
               key="${BASH_REMATCH[1]}"
             else
-              # Fallback: clean up the full line and use as key
               key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
             fi
             rest=$(echo "$rest" | xargs)
@@ -151,77 +117,8 @@ runs:
                  grep -v "/errorreport:" | \
                  grep -v "::warning::" || true)
         
-        # Pattern 2: Broader warning pattern (fallback)
-        while IFS=':' read -r full_line rest; do
-          if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Create a unique key from the warning
-            key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              rest=$(echo "$rest" | xargs)
-              warnings_map["$key"]="$rest"
-            fi
-          fi
-        done < <(grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" || true)
-        
-        # Pattern 3: Even broader - any line with "warning" and a code
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Extract a reasonable key from the line
-            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
-            fi
-          fi
-        done < <(grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" | \
-                 head -50 || true)
-        
-        # Pattern 4: Look for CS0219 specifically (unused variable warning)
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Extract a reasonable key from the line
-            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
-            fi
-          fi
-        done < <(grep -iE "CS0219" "$BUILD_OUTPUT" | head -10 || true)
-        
-        # Pattern 5: Look for any suppressed warnings or warning-related output
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Use the full line as key for suppressed warnings
-            key=$(echo "$line" | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
-            fi
-          fi
-        done < <(grep -iE "(nowarn|suppress.*warning)" "$BUILD_OUTPUT" | head -5 || true)
-        
         WARNING_COUNT=${#warnings_map[@]}
-        
-        # Debug: Show what warnings were found
-        echo "::group::Debug - Warnings Found ($WARNING_COUNT)"
-        if [[ $WARNING_COUNT -gt 0 ]]; then
-          for key in "${!warnings_map[@]}"; do
-            echo "Key: $key"
-            echo "Value: ${warnings_map[$key]}"
-            echo "---"
-          done
-        else
-          echo "No warnings found with any pattern"
-          echo "Checking if CS0219 appears anywhere in output:"
-          grep -i "CS0219" "$BUILD_OUTPUT" || echo "CS0219 not found"
-          echo "Checking warning suppression:"
-          grep -i "nowarn" "$BUILD_OUTPUT" || echo "No nowarn found"
-        fi
-        echo "::endgroup::"
-        
+                
         # Determine build success
         BUILD_SUCCESS=true
         if [[ $BUILD_EXIT_CODE -ne 0 ]] || [[ $ERROR_COUNT -gt 0 ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -81,30 +81,6 @@ runs:
         
         echo "::endgroup::"
         
-        # Process warnings using associative array for deduplication
-        # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
-        # Exclude compiler command lines and GitHub Actions annotations
-        declare -A warnings_map
-        while IFS=':' read -r full_line rest; do
-          if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
-            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
-            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
-              key="${BASH_REMATCH[1]}"
-            else
-              # Fallback: clean up the full line and use as key
-              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
-            fi
-            rest=$(echo "$rest" | xargs)
-            warnings_map["$key"]="$rest"
-          fi
-        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" || true)
-        
-        WARNING_COUNT=${#warnings_map[@]}
-        
         # Process errors using associative array for deduplication
         # Use specific pattern to match MSBuild error format: file(line,col): error CODE: message
         # Exclude compiler command lines and GitHub Actions annotations
@@ -128,6 +104,30 @@ runs:
                  grep -v "::error::" || true)
         
         ERROR_COUNT=${#errors_map[@]}
+        
+        # Process warnings using associative array for deduplication
+        # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
+        # Exclude compiler command lines and GitHub Actions annotations
+        declare -A warnings_map
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
+            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
+            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
+              key="${BASH_REMATCH[1]}"
+            else
+              # Fallback: clean up the full line and use as key
+              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            fi
+            rest=$(echo "$rest" | xargs)
+            warnings_map["$key"]="$rest"
+          fi
+        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" || true)
+        
+        WARNING_COUNT=${#warnings_map[@]}
         
         # Determine build success
         BUILD_SUCCESS=true

--- a/action.yaml
+++ b/action.yaml
@@ -68,27 +68,76 @@ runs:
         ADDITIONAL_BUILD_ARGUMENTS: ${{ inputs.additional-build-arguments }}
       run: |
         echo "::group::Build Output"
-        OUTPUT=$(dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} 2>&1)
-        echo "$OUTPUT"
+        
+        # Create build log file
+        BUILD_LOG="build-output.log"
+        
+        # Run build and capture both stdout and stderr, preserve exit code
+        set +e
+        dotnet build ${SOLUTION_PATH} --no-restore --configuration ${BUILD_CONFIGURATION} ${ADDITIONAL_BUILD_ARGUMENTS} 2>&1 | tee "$BUILD_LOG"
+        BUILD_EXIT_CODE=$?
+        set -e
+        
         echo "::endgroup::"
-
-        ERROR_COUNT=$(echo "$OUTPUT" | grep -cE 'error\s[A-Z]{4}[0-9]{4}:')
-        WARNING_COUNT=$(echo "$OUTPUT" | grep -cE 'warning\s[A-Z]{4}[0-9]{4}:')
-
-        if [[ "$ERROR_COUNT" -gt 0 ]]; then
-          echo "$OUTPUT" | grep -E 'error\s[A-Z]{4}[0-9]{4}:' | while read -r line; do
-            echo "::error::❌ $line"
-          done
-          echo "::error::❌ Build failed with $ERROR_COUNT error(s)"
+        
+        # Initialize summary
+        echo "## 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Parse build output for errors and warnings
+        ERROR_COUNT=$(grep -cE 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
+        WARNING_COUNT=$(grep -cE 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
+        
+        if [[ "$BUILD_EXIT_CODE" -ne 0 ]] || [[ "$ERROR_COUNT" -gt 0 ]]; then
+          echo "❌ **Build Status:** FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Errors:** $ERROR_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "- **Warnings:** $WARNING_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "- **Exit Code:** $BUILD_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Show errors in summary
+          if [[ "$ERROR_COUNT" -gt 0 ]]; then
+            echo "### ❌ Build Errors" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | head -10 >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Also output as GitHub annotations
+            grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | while read -r line; do
+              echo "::error::❌ $line"
+            done
+          fi
+          
+          echo "::error::❌ Build failed with $ERROR_COUNT error(s) and $WARNING_COUNT warning(s)"
           exit 1
-        elif [[ "$WARNING_COUNT" -gt 0 ]]; then
-          echo "$OUTPUT" | grep -E 'warning\s[A-Z]{4}[0-9]{4}:' | while read -r line; do
-            echo "::warning::⚠️ $line"
-          done
-          echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
         else
-          echo "::notice::✅ Build succeeded with no warnings or errors"
+          echo "✅ **Build Status:** SUCCESS" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Errors:** $ERROR_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "- **Warnings:** $WARNING_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "$WARNING_COUNT" -gt 0 ]]; then
+            echo "### ⚠️ Build Warnings" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | head -10 >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Also output as GitHub annotations
+            grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | while read -r line; do
+              echo "::warning::⚠️ $line"
+            done
+            echo "::warning::⚠️ Build succeeded with $WARNING_COUNT warning(s)"
+          else
+            echo "::notice::✅ Build succeeded with no warnings or errors"
+          fi
         fi
+        
+        # Upload build log as artifact
+        echo "BUILD_LOG_PATH=$BUILD_LOG" >> $GITHUB_ENV
 
     - name: Run tests
       shell: bash
@@ -99,32 +148,112 @@ runs:
         ADDITIONAL_TEST_ARGUMENTS: ${{ inputs.additional-test-arguments }}
       run: |
         echo "::group::Test Output"
-        OUTPUT=$(dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} --logger "trx;LogFileName=test-results.trx" 2>&1 || true)
-        echo "$OUTPUT"
+        
+        # Create test log file
+        TEST_LOG="test-output.log"
+        
+        # Run tests and capture both stdout and stderr, preserve exit code
+        set +e
+        dotnet test ${SOLUTION_PATH} --no-build --configuration ${BUILD_CONFIGURATION} --verbosity ${TEST_VERBOSITY} ${ADDITIONAL_TEST_ARGUMENTS} --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed" 2>&1 | tee "$TEST_LOG"
+        TEST_EXIT_CODE=$?
+        set -e
+        
         echo "::endgroup::"
-
-        PASSED=$(echo "$OUTPUT" | grep -oP 'Passed: \K[0-9]+')
-        FAILED=$(echo "$OUTPUT" | grep -oP 'Failed: \K[0-9]+')
-        SKIPPED=$(echo "$OUTPUT" | grep -oP 'Skipped: \K[0-9]+')
-
-        # Highlight failed tests by name
-        echo "$OUTPUT" | grep -A1 'Failed ' | grep -E '^\s*[^ ]+\s*\[.*\]' | while read -r line; do
-          TEST_NAME=$(echo "$line" | awk '{print $1}')
-          echo "::error::❌ Failed Test: $TEST_NAME"
-        done
-
-        # Highlight skipped tests by name
-        echo "$OUTPUT" | grep -A1 'Skipped ' | grep -E '^\s*[^ ]+\s*\[.*\]' | while read -r line; do
-          TEST_NAME=$(echo "$line" | awk '{print $1}')
-          echo "::warning::⚠️ Skipped Test: $TEST_NAME"
-        done
-
-        if [[ "$FAILED" -gt 0 ]]; then
-          echo "::error::❌ $FAILED test(s) failed"
-          exit 1
-        elif [[ "$SKIPPED" -gt 0 ]]; then
-          echo "::warning::⚠️ $SKIPPED test(s) skipped"
-          echo "::notice::✅ $PASSED test(s) passed"
-        else
-          echo "::notice::✅ All $PASSED test(s) passed"
+        
+        # Add test results to summary
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "## 🧪 Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Parse test output for results
+        PASSED=$(grep -oP 'Passed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        FAILED=$(grep -oP 'Failed:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        SKIPPED=$(grep -oP 'Skipped:\s*\K[0-9]+' "$TEST_LOG" | tail -1 || echo "0")
+        TOTAL=$((PASSED + FAILED + SKIPPED))
+        
+        # Handle case where no tests were found
+        if [[ "$TOTAL" -eq 0 ]]; then
+          # Try alternative parsing for different dotnet output formats
+          PASSED=$(grep -oP 'Passed!\s*-\s*Failed:\s*0,\s*Passed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
+          FAILED=$(grep -oP 'Failed!\s*-\s*Failed:\s*\K[0-9]+' "$TEST_LOG" || echo "0")
+          TOTAL=$((PASSED + FAILED + SKIPPED))
         fi
+        
+        if [[ "$TEST_EXIT_CODE" -ne 0 ]] || [[ "$FAILED" -gt 0 ]]; then
+          echo "❌ **Test Status:** FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total Tests:** $TOTAL" >> $GITHUB_STEP_SUMMARY
+          echo "- **Passed:** $PASSED" >> $GITHUB_STEP_SUMMARY
+          echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "- **Skipped:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
+          echo "- **Exit Code:** $TEST_EXIT_CODE" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Show failed tests in summary
+          if [[ "$FAILED" -gt 0 ]]; then
+            echo "### ❌ Failed Tests" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            
+            # Extract failed test names from output
+            grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 >> $GITHUB_STEP_SUMMARY || echo "Failed test details not available in this format" >> $GITHUB_STEP_SUMMARY
+            
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Also output as GitHub annotations
+            grep -E "(FAIL|Failed)" "$TEST_LOG" | grep -v "Failed:" | head -10 | while read -r line; do
+              echo "::error::❌ Failed Test: $line"
+            done
+          fi
+          
+          echo "::error::❌ $FAILED test(s) failed out of $TOTAL total tests"
+          exit 1
+        else
+          echo "✅ **Test Status:** SUCCESS" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total Tests:** $TOTAL" >> $GITHUB_STEP_SUMMARY
+          echo "- **Passed:** $PASSED" >> $GITHUB_STEP_SUMMARY
+          echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "- **Skipped:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "$SKIPPED" -gt 0 ]]; then
+            echo "### ⚠️ Skipped Tests" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E "(SKIP|Skipped)" "$TEST_LOG" | grep -v "Skipped:" | head -10 >> $GITHUB_STEP_SUMMARY || echo "Skipped test details not available in this format" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            echo "::warning::⚠️ $SKIPPED test(s) skipped"
+          fi
+          
+          if [[ "$TOTAL" -gt 0 ]]; then
+            echo "::notice::✅ All $PASSED test(s) passed out of $TOTAL total tests"
+          else
+            echo "::warning::⚠️ No tests found to execute"
+          fi
+        fi
+        
+        # Set environment variables for potential artifact upload
+        echo "TEST_LOG_PATH=$TEST_LOG" >> $GITHUB_ENV
+        echo "TEST_RESULTS_PATH=test-results.trx" >> $GITHUB_ENV
+
+    - name: Upload Build and Test Logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: build-and-test-logs
+        path: |
+          ${{ env.BUILD_LOG_PATH }}
+          ${{ env.TEST_LOG_PATH }}
+          ${{ env.TEST_RESULTS_PATH }}
+        retention-days: 30
+
+    - name: Publish Test Results
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: .NET Test Results
+        path: ${{ env.TEST_RESULTS_PATH }}
+        reporter: dotnet-trx
+        fail-on-error: false

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,7 @@ runs:
         
         # Process warnings using associative array for deduplication
         # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
+        # Exclude compiler command lines and GitHub Actions annotations
         declare -A warnings_map
         while IFS=':' read -r full_line rest; do
           if [[ -n "$full_line" && -n "$rest" ]]; then
@@ -97,7 +98,10 @@ runs:
             rest=$(echo "$rest" | xargs)
             warnings_map["$key"]="$rest"
           fi
-        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" || true)
+        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::warning::" || true)
         
         WARNING_COUNT=${#warnings_map[@]}
         

--- a/action.yaml
+++ b/action.yaml
@@ -82,6 +82,7 @@ runs:
         echo "::endgroup::"
         
         # Process warnings using associative array for deduplication
+        # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
         declare -A warnings_map
         while IFS=':' read -r key rest; do
           if [[ -n "$key" && -n "$rest" ]]; then
@@ -90,11 +91,13 @@ runs:
             rest=$(echo "$rest" | xargs)
             warnings_map["$key"]="$rest"
           fi
-        done < <(grep -i "warning" "$BUILD_OUTPUT" || true)
+        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" || true)
         
         WARNING_COUNT=${#warnings_map[@]}
         
         # Process errors using associative array for deduplication
+        # Use specific pattern to match MSBuild error format: file(line,col): error CODE: message
+        # Exclude compiler command lines and GitHub Actions annotations
         declare -A errors_map
         while IFS=':' read -r key rest; do
           if [[ -n "$key" && -n "$rest" ]]; then
@@ -103,7 +106,10 @@ runs:
             rest=$(echo "$rest" | xargs)
             errors_map["$key"]="$rest"
           fi
-        done < <(grep -i "error" "$BUILD_OUTPUT" | grep -v "::error::" || true)
+        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*error\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
+                 grep -v "/usr/share/dotnet/dotnet exec" | \
+                 grep -v "/errorreport:" | \
+                 grep -v "::error::" || true)
         
         ERROR_COUNT=${#errors_map[@]}
         

--- a/action.yaml
+++ b/action.yaml
@@ -84,10 +84,16 @@ runs:
         # Process warnings using associative array for deduplication
         # Use specific pattern to match MSBuild warning format: file(line,col): warning CODE: message
         declare -A warnings_map
-        while IFS=':' read -r key rest; do
-          if [[ -n "$key" && -n "$rest" ]]; then
-            # Clean up the key and value
-            key=$(echo "$key" | xargs)
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
+            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
+            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
+              key="${BASH_REMATCH[1]}"
+            else
+              # Fallback: clean up the full line and use as key
+              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            fi
             rest=$(echo "$rest" | xargs)
             warnings_map["$key"]="$rest"
           fi
@@ -99,10 +105,16 @@ runs:
         # Use specific pattern to match MSBuild error format: file(line,col): error CODE: message
         # Exclude compiler command lines and GitHub Actions annotations
         declare -A errors_map
-        while IFS=':' read -r key rest; do
-          if [[ -n "$key" && -n "$rest" ]]; then
-            # Clean up the key and value
-            key=$(echo "$key" | xargs)
+        while IFS=':' read -r full_line rest; do
+          if [[ -n "$full_line" && -n "$rest" ]]; then
+            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
+            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
+            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
+              key="${BASH_REMATCH[1]}"
+            else
+              # Fallback: clean up the full line and use as key
+              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
+            fi
             rest=$(echo "$rest" | xargs)
             errors_map["$key"]="$rest"
           fi

--- a/action.yaml
+++ b/action.yaml
@@ -105,122 +105,61 @@ runs:
         
         ERROR_COUNT=${#errors_map[@]}
         
-        # Debug: Show sample of build output for troubleshooting
-        echo "::group::Debug - Build Output Sample (first 50 lines)"
-        head -50 "$BUILD_OUTPUT" || true
-        echo "::endgroup::"
-        
-        echo "::group::Debug - Lines containing 'warning'"
-        grep -i "warning" "$BUILD_OUTPUT" | head -20 || echo "No lines containing 'warning' found"
-        echo "::endgroup::"
-        
-        echo "::group::Debug - Raw grep patterns test"
-        echo "Testing Pattern 1 (strict MSBuild):"
-        grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 1"
-        echo ""
-        echo "Testing Pattern 2 (broader):"
-        grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 2"
-        echo ""
-        echo "Testing Pattern 3 (broadest):"
-        grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | head -5 || echo "No matches for Pattern 3"
-        echo ""
-        echo "File size and line count:"
-        wc -l "$BUILD_OUTPUT" || echo "Could not count lines"
-        echo "::endgroup::"
         
         # Process warnings using associative array for deduplication
-        # Use multiple patterns to catch different warning formats
+        # Focus on actual MSBuild warning messages, not compiler command lines
         declare -A warnings_map
         
+        # Enhanced filtering function to exclude compiler commands and noise
+        filter_compiler_noise() {
+          grep -v "/usr/share/dotnet/dotnet exec" | \
+          grep -v "/usr/share/dotnet/sdk/" | \
+          grep -v "Roslyn/bincore/csc.dll" | \
+          grep -v "/errorreport:" | \
+          grep -v "/nowarn:" | \
+          grep -v "/reference:" | \
+          grep -v "/define:" | \
+          grep -v "/analyzer:" | \
+          grep -v "::warning::" | \
+          grep -v "^[[:space:]]*$"
+        }
+        
         # Pattern 1: Standard MSBuild format: file(line,col): warning CODE: message
-        while IFS=':' read -r full_line rest; do
-          if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Extract the meaningful part as key: everything after /home/runner/work/ up to the first :
-            # This handles cases like "3>/home/runner/work/..." by extracting just the file path and location
-            if [[ "$full_line" =~ /home/runner/work/([^:]+) ]]; then
-              key="${BASH_REMATCH[1]}"
-            else
-              # Fallback: clean up the full line and use as key
-              key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
-            fi
-            rest=$(echo "$rest" | xargs)
-            warnings_map["$key"]="$rest"
-          fi
-        done < <(grep -E "^\s*[^:]*\([0-9]+,[0-9]+\):\s*warning\s+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" || true)
-        
-        # Pattern 2: Broader warning pattern (fallback)
-        while IFS=':' read -r full_line rest; do
-          if [[ -n "$full_line" && -n "$rest" ]]; then
-            # Create a unique key from the warning
-            key=$(echo "$full_line" | sed 's/^[0-9]*>//' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              rest=$(echo "$rest" | xargs)
-              warnings_map["$key"]="$rest"
-            fi
-          fi
-        done < <(grep -iE "warning\s+[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" || true)
-        
-        # Pattern 3: Even broader - any line with "warning" and a code
+        # This is the most reliable pattern for actual warnings
         while IFS= read -r line; do
           if [[ -n "$line" ]]; then
-            # Extract a reasonable key from the line
-            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
+            # Extract file and location for the key
+            if [[ "$line" =~ ([^/]+\([0-9]+,[0-9]+\)):[[:space:]]*warning[[:space:]]+([A-Z]{2}[0-9]{4}):[[:space:]]*(.+) ]]; then
+              file_location="${BASH_REMATCH[1]}"
+              warning_code="${BASH_REMATCH[2]}"
+              warning_message="${BASH_REMATCH[3]}"
+              key="$file_location"
+              warnings_map["$key"]="warning $warning_code: $warning_message"
             fi
           fi
-        done < <(grep -iE "warning.*[A-Z]{2}[0-9]{4}" "$BUILD_OUTPUT" | \
-                 grep -v "/usr/share/dotnet/dotnet exec" | \
-                 grep -v "/errorreport:" | \
-                 grep -v "::warning::" | \
-                 head -50 || true)
+        done < <(grep -E "\([0-9]+,[0-9]+\):[[:space:]]*warning[[:space:]]+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | filter_compiler_noise || true)
         
-        # Pattern 4: Look for CS0219 specifically (unused variable warning)
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Extract a reasonable key from the line
-            key=$(echo "$line" | sed -E 's/^[0-9]*>//; s/.*\/([^\/]+\([0-9]+,[0-9]+\)).*/\1/' | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
+        # Pattern 2: Alternative format - look for warnings in project files or other contexts
+        # Only if we haven't found warnings with Pattern 1
+        if [[ ${#warnings_map[@]} -eq 0 ]]; then
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              # Look for warning code and extract meaningful parts
+              if [[ "$line" =~ warning[[:space:]]+([A-Z]{2}[0-9]{4}):[[:space:]]*(.+) ]]; then
+                warning_code="${BASH_REMATCH[1]}"
+                warning_message="${BASH_REMATCH[2]}"
+                # Use warning code as key to avoid duplicates
+                key="$warning_code"
+                if [[ -z "${warnings_map[$key]}" ]]; then
+                  warnings_map["$key"]="warning $warning_code: $warning_message"
+                fi
+              fi
             fi
-          fi
-        done < <(grep -iE "CS0219" "$BUILD_OUTPUT" | head -10 || true)
-        
-        # Pattern 5: Look for any suppressed warnings or warning-related output
-        while IFS= read -r line; do
-          if [[ -n "$line" ]]; then
-            # Use the full line as key for suppressed warnings
-            key=$(echo "$line" | xargs)
-            if [[ -n "$key" && -z "${warnings_map[$key]}" ]]; then
-              warnings_map["$key"]="$line"
-            fi
-          fi
-        done < <(grep -iE "(nowarn|suppress.*warning)" "$BUILD_OUTPUT" | head -5 || true)
+          done < <(grep -iE "warning[[:space:]]+[A-Z]{2}[0-9]{4}:" "$BUILD_OUTPUT" | filter_compiler_noise | head -20 || true)
+        fi
         
         WARNING_COUNT=${#warnings_map[@]}
         
-        # Debug: Show what warnings were found
-        echo "::group::Debug - Warnings Found ($WARNING_COUNT)"
-        if [[ $WARNING_COUNT -gt 0 ]]; then
-          for key in "${!warnings_map[@]}"; do
-            echo "Key: $key"
-            echo "Value: ${warnings_map[$key]}"
-            echo "---"
-          done
-        else
-          echo "No warnings found with any pattern"
-          echo "Checking if CS0219 appears anywhere in output:"
-          grep -i "CS0219" "$BUILD_OUTPUT" || echo "CS0219 not found"
-          echo "Checking warning suppression:"
-          grep -i "nowarn" "$BUILD_OUTPUT" || echo "No nowarn found"
-        fi
-        echo "::endgroup::"
         
         # Determine build success
         BUILD_SUCCESS=true

--- a/action.yaml
+++ b/action.yaml
@@ -84,17 +84,20 @@ runs:
         echo "## 🔨 Build Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Parse build output for errors and warnings with multiple patterns
-        # Try different patterns to catch various .NET warning/error formats
-        ERROR_COUNT=$(grep -ciE '(error\s[A-Z]+[0-9]+:|error:|^\s*error\s)' "$BUILD_LOG" || echo "0")
-        WARNING_COUNT=$(grep -ciE '(warning\s[A-Z]+[0-9]+:|warning:|^\s*warning\s)' "$BUILD_LOG" || echo "0")
+        # Parse build output for errors and warnings with precise patterns
+        # Use more specific patterns to avoid false matches
+        ERROR_COUNT=$(grep -cE 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
+        WARNING_COUNT=$(grep -cE 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" || echo "0")
         
-        # Extract unique errors and warnings for display using broader patterns
-        UNIQUE_ERRORS=$(grep -iE '(error\s[A-Z]+[0-9]+:|error:|^\s*error\s)' "$BUILD_LOG" | sort -u || true)
-        UNIQUE_WARNINGS=$(grep -iE '(warning\s[A-Z]+[0-9]+:|warning:|^\s*warning\s)' "$BUILD_LOG" | sort -u || true)
+        # Extract unique errors and warnings for display
+        UNIQUE_ERRORS=$(grep -E 'error\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u || true)
+        UNIQUE_WARNINGS=$(grep -E 'warning\s[A-Z]{2}[0-9]{4}:' "$BUILD_LOG" | sort -u || true)
         
         # Debug output to help troubleshoot warning detection
         echo "::debug::Found $ERROR_COUNT errors and $WARNING_COUNT warnings in build log"
+        echo "::debug::Checking for any lines containing 'warning' (case insensitive):"
+        grep -i 'warning' "$BUILD_LOG" | head -5 || echo "::debug::No lines containing 'warning' found"
+        
         if [[ "$WARNING_COUNT" -gt 0 ]]; then
           echo "::debug::Sample warnings found:"
           echo "$UNIQUE_WARNINGS" | head -3 | while read -r line; do
@@ -174,8 +177,8 @@ runs:
           fi
         fi
         
-        # Upload build log as artifact
-        echo "BUILD_LOG_PATH=$BUILD_LOG" >> $GITHUB_ENV
+        # Set absolute path for build log artifact
+        echo "BUILD_LOG_PATH=$PWD/$BUILD_LOG" >> $GITHUB_ENV
 
     - name: Run tests
       shell: bash
@@ -272,9 +275,9 @@ runs:
           fi
         fi
         
-        # Set environment variables for potential artifact upload
-        echo "TEST_LOG_PATH=$TEST_LOG" >> $GITHUB_ENV
-        echo "TEST_RESULTS_PATH=test-results.trx" >> $GITHUB_ENV
+        # Set absolute paths for test artifacts
+        echo "TEST_LOG_PATH=$PWD/$TEST_LOG" >> $GITHUB_ENV
+        echo "TEST_RESULTS_PATH=$PWD/test-results.trx" >> $GITHUB_ENV
 
     - name: Upload Build and Test Logs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Overview,

The purpose of this project is to provide a GitHub Actions-native CI tool for .NET projects. This tool has several features:
- Build code and run all unit tests
- Surface and summarize errors with rich formatting
- Easy implementation and reusability

## TODO

At some point in the  future it would be good to make it so that errors and warnings are passed to the PR summary as comments, but this is not strictly necessary at this point in time.

# Testing

In order to test this, several test cases were defined and a project, [DotNet.CICDTest](https://github.com/jmsudar/DotNet.CICDTest) was created. This project is just a simple hello-world, with its primary use being to create errors, warnings, test failures, and finally success cases. These runs are then tested in GHA and the expected cases detailed below.

## Failing unit test

In the case of a failing unit test, we want the run to fail.

### Local `dotnet test`

```shell
DotNet.CICDTest % dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  DotNet.CICDTest -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/bin/Debug/net6.0/DotNet.CICDTest.dll
  DotNet.CICDTest.Tests -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll
Test run for /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.6.3 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Failed TestGetGreeting [46 ms]
  Error Message:
   Assert.AreEqual failed. Expected:<Hello, Universe!>. Actual:<Hello, World!>. 
  Stack Trace:
     at DotNet.CICDTest.Tests.TestMethodsTests.TestGetGreeting() in /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs:line 29


Failed!  - Failed:     1, Passed:     2, Skipped:     0, Total:     3, Duration: 86 ms - DotNet.CICDTest.Tests.dll (net6.0)
```

### GHA run

[Link to run](https://github.com/jmsudar/DotNet.CICDTest/actions/runs/18432913652)

#### Result

```shell
  Build FAILED.
      0 Warning(s)
      0 Error(s)
  Time Elapsed 00:00:02.53
Error: ❌ Failed Test:   Failed TestGetGreeting [21 ms]
Error: ❌ Failed Test: Test Run Failed.
Error: ❌ Failed Test:      3>Done Building Project "/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.csproj" (VSTest target(s)) -- FAILED.
Error: ❌ Failed Test:      1>Done Building Project "/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/DotNet.CICDTest.sln" (VSTest target(s)) -- FAILED.
Error: ❌ Failed Test: Build FAILED.
Error: ❌ 1 test(s) failed out of 3 total tests
Error: Process completed with exit code 1.
Run # Generate final summary section
Error: 💥 CI pipeline failed - check the details above
```

<img width="1340" height="527" alt="Screenshot 2025-10-11 at 11 06 20 AM" src="https://github.com/user-attachments/assets/384c8977-2401-49e6-b571-612a83615c11" />

## Two errors

In this case, two return errors cause the build to fail. The simulated run from checking this in then is expected to surface this result on the GitHub Actions landing page and present the information helpfully.

### Local `dotnet build`

```shell
DotNet.CICDTest % dotnet build
MSBuild version 17.6.11+5eb99e6e9 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: 'TestMethods.Add(int, int)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(38,30): error CS0161: 'TestMethods.Concat(string, string)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]

Build FAILED.

/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: 'TestMethods.Add(int, int)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(38,30): error CS0161: 'TestMethods.Concat(string, string)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
    0 Warning(s)
    2 Error(s)

Time Elapsed 00:00:04.37
```

### GHA run

[Link to run](https://github.com/jmsudar/DotNet.CICDTest/actions/runs/18432798988)

#### Result

```shell
  Build FAILED.
      0 Warning(s)
      2 Error(s)
  Time Elapsed 00:00:03.69
Error: DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(38,30): error CS0161: TestMethods.Concat(string, string): not all code paths return a value [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
Error: DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: TestMethods.Add(int, int): not all code paths return a value [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
Error: ❌ Build failed with 2 error(s)
Error: Process completed with exit code 1.
Run # Generate final summary section
Error: 💥 CI pipeline failed - check the details above
```
<img width="1317" height="611" alt="Screenshot 2025-10-11 at 10 53 59 AM" src="https://github.com/user-attachments/assets/19e3f8ed-aff0-4a71-a3ef-2f8d6398550e" />

## One error and one warning

Here, we expect the build to fail from a single return error and also to alert about there being one warning due to an unused variable.

### Local `dotnet build`

```shell
DotNet.CICDTest % dotnet build
MSBuild version 17.6.11+5eb99e6e9 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable 'unusedVariable' is assigned but its value is never used [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: 'TestMethods.Add(int, int)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]

Build FAILED.

/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable 'unusedVariable' is assigned but its value is never used [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: 'TestMethods.Add(int, int)': not all code paths return a value [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
    1 Warning(s)
    1 Error(s)
```

### GHA run

[Link to run](https://github.com/jmsudar/DotNet.CICDTest/actions/runs/18432835747)

#### Result

```shell
  Build FAILED.
      1 Warning(s)
      1 Error(s)
  Time Elapsed 00:00:08.35
Error: DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(26,27): error CS0161: TestMethods.Add(int, int): not all code paths return a value [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
Warning: DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable unusedVariable is assigned but its value is never used [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
Error: ❌ Build failed with 1 error(s) and 1 warning(s)
Error: Process completed with exit code 1.
Run # Generate final summary section
Error: 💥 CI pipeline failed - check the details above
```

<img width="1322" height="655" alt="Screenshot 2025-10-11 at 10 58 59 AM" src="https://github.com/user-attachments/assets/854eb72b-cd07-4333-b29d-77a84b59872d" />

## Warning only

A run where there are warnings but not errors should report this to the user but should not fail the run.

### Local `dotnet build`

```shell
DotNet.CICDTest % dotnet build
MSBuild version 17.6.11+5eb99e6e9 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable 'unusedVariable' is assigned but its value is never used [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
  DotNet.CICDTest -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/bin/Debug/net6.0/DotNet.CICDTest.dll
  DotNet.CICDTest.Tests -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll

Build succeeded.

/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable 'unusedVariable' is assigned but its value is never used [/Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.68
```

### GHA run

[Link to run](https://github.com/jmsudar/DotNet.CICDTest/actions/runs/18432980441/job/52522761826)

#### Result

```shell
  Build succeeded.
         "/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/DotNet.CICDTest.sln" (default target) (1) ->
         "/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj" (default target) (3) ->
         (CoreCompile target) -> 
           /home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable 'unusedVariable' is assigned but its value is never used [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
      1 Warning(s)
      0 Error(s)
  Time Elapsed 00:00:05.50
Warning: DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.cs(15,20): warning CS0219: The variable unusedVariable is assigned but its value is never used [/home/runner/work/DotNet.CICDTest/DotNet.CICDTest/src/DotNet.CICDTest/DotNet.CICDTest.csproj]
Warning: ⚠️ Build succeeded with 1 warning(s)
```

<img width="1327" height="884" alt="Screenshot 2025-10-11 at 11 12 31 AM" src="https://github.com/user-attachments/assets/cccbe73a-f95b-4e72-84d1-353c14a7288e" />

## No errors, no warnings

Finally, no errors and no warnings should result in a successful build, a passing GHA check, and a clean report.

### Local `dotnet build`

```shell
DotNet.CICDTest % dotnet build
MSBuild version 17.6.11+5eb99e6e9 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  DotNet.CICDTest -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/bin/Debug/net6.0/DotNet.CICDTest.dll
  DotNet.CICDTest.Tests -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.47

DotNet.CICDTest % dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  DotNet.CICDTest -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest/bin/Debug/net6.0/DotNet.CICDTest.dll
  DotNet.CICDTest.Tests -> /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll
Test run for /Users/sudar/Dropbox/Programming/DotNet.CICDTest/src/DotNet.CICDTest.Tests/bin/Debug/net6.0/DotNet.CICDTest.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.6.3 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 43 ms - DotNet.CICDTest.Tests.dll (net6.0)
```

### GHA run

[Link to run](https://github.com/jmsudar/DotNet.CICDTest/actions/runs/18433056454)

#### Result

```shell
  Build succeeded.
      0 Warning(s)
      0 Error(s)
  Time Elapsed 00:00:06.93
Notice: ✅ Build succeeded with no errors or warnings

Notice: ✅ All 3 test(s) passed
```

<img width="1318" height="794" alt="Screenshot 2025-10-11 at 11 18 19 AM" src="https://github.com/user-attachments/assets/7d4a0016-56db-4b33-a579-0f25f6103534" />
